### PR TITLE
Fix #119: Ensure a multipart Content-Type header is used when sending attachments.

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -186,7 +186,10 @@ export default class Collection {
     const {permissions} = reqOptions;
     const id = record.id || uuid.v4();
     const path = endpoint("attachment", this.bucket.name, this.name, id);
-    const addAttachmentRequest = requests.addAttachmentRequest(path, dataURI, {data: record, permissions}, reqOptions);
+    const addAttachmentRequest = requests.addAttachmentRequest(path, dataURI, {
+      data: record,
+      permissions
+    }, reqOptions);
     return this.client.execute(addAttachmentRequest, {stringify: false})
       .then(() => this.getRecord(id));
   }

--- a/src/http.js
+++ b/src/http.js
@@ -78,6 +78,11 @@ export default class HTTP {
     let response, status, statusText, headers, hasTimedout;
     // Ensure default request headers are always set
     options.headers = {...HTTP.DEFAULT_REQUEST_HEADERS, ...options.headers};
+    // If a multipart body is provided, remove any custom Content-Type header as
+    // the fetch() implementation will add the correct one for us.
+    if (options.body && typeof options.body.append === "function") {
+      delete options.headers["Content-Type"];
+    }
     options.mode = this.requestMode;
     return new Promise((resolve, reject) => {
       const _timeoutId = setTimeout(() => {

--- a/src/requests.js
+++ b/src/requests.js
@@ -108,8 +108,6 @@ export function addAttachmentRequest(path, dataURI, {data, permissions}={}, opti
     headers: {
       ...headers,
       ...safeHeader(safe, last_modified),
-      // Setting content type as undefined so that it does not use default "application/json".
-      "Content-Type": undefined
     },
     body: formData
   };

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -62,6 +62,15 @@ describe("HTTP class", () => {
 
         expect(fetch.firstCall.args[1].headers.Foo).eql("Bar");
       });
+
+      it("should drop custom content-type header for multipart body", () => {
+        http.request("/", {
+          headers: {"Content-Type": "application/foo"},
+          body: new FormData()
+        });
+
+        expect(fetch.firstCall.args[1].headers["Content-Type"]).to.be.undefined;
+      });
     });
 
     describe("Request CORS mode", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -991,7 +991,7 @@ describe("Integration tests", function() {
               beforeEach(() => {
                 return coll
                   .addAttachment(dataURL, {foo: "bar"}, {
-                    permissions: {write: ["github:n1k0"]}
+                    permissions: {write: ["github:n1k0"]},
                   })
                   .then(res => result = res);
               });
@@ -1017,8 +1017,9 @@ describe("Integration tests", function() {
             });
 
             describe("Without filename", () => {
+              const dataURL = "data:text/plain;base64," + btoa("blah");
+
               it("should default filename to 'untitled' if not specified", () => {
-                const dataURL = "data:text/plain;base64," + btoa("blah");
                 return coll
                   .addAttachment(dataURL)
                   .should.eventually
@@ -1028,9 +1029,8 @@ describe("Integration tests", function() {
               });
 
               it("should allow to specify a filename in options", () => {
-                const dataURL = "data:text/plain;base64," + btoa("blah");
                 return coll
-                  .addAttachment(dataURL, {}, {filename: "MYFILE.DAT"})
+                  .addAttachment(dataURL, undefined, {filename: "MYFILE.DAT"})
                   .should.eventually
                   .have.property("data")
                   .have.property("attachment")

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -20,8 +20,6 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 kinto.attachment.keep_old_files = true
 kinto.attachment.base_path = /tmp
 
-kinto.experimental_permissions_endpoint = true
-
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -20,6 +20,8 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 kinto.attachment.keep_old_files = true
 kinto.attachment.base_path = /tmp
 
+kinto.experimental_permissions_endpoint = true
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0

--- a/test/requests_test.js
+++ b/test/requests_test.js
@@ -145,7 +145,7 @@ describe("requests module", () => {
 
     it("should accept a headers option", () => {
       expect(requests.addAttachmentRequest("/foo", dataURL, {}, {headers: {Foo: "Bar"}}))
-        .to.have.property("headers").eql({"Content-Type": undefined, Foo: "Bar"});
+        .to.have.property("headers").eql({Foo: "Bar"});
     });
 
     it("should raise for safe with no last_modified passed", () => {


### PR DESCRIPTION
Refs #119. This is ugly, but I couldn't find any better generic way to check for a multipart request body :disappointed:  

Tested the patch on kinto-admin, solves the issue.

r=? @leplatrem