### PR TITLE
Fix #122: Add support for the /permissions endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Read the [API documentation](https://doc.esdoc.org/github.com/Kinto/kinto-http.j
      - [Deleting record](#deleting-record)
      - [Listing records](#listing-records)
      - [Batching operations](#batching-operations)
+  - [Listing all resource permissions](#listing-all-resource-permissions)
   - [Attachments](#attachments)
      - [Adding an attachment to a record](#adding-an-attachment-to-a-record)
      - [Updating an attachment](#updating-an-attachment)
@@ -1152,21 +1153,21 @@ Sample result:
 
 ```js
 {
-    "data": [
-        {
-            "bucket_id": "mybucket",
-            "id": "mybucket",
-            "permissions": [
-                "write",
-                "read",
-                "group:create",
-                "collection:create"
-            ],
-            "resource_name": "bucket",
-            "uri": "/buckets/mybucket"
-        },
-        ...
-    ]
+  "data": [
+    {
+      "bucket_id": "mybucket",
+      "id": "mybucket",
+      "permissions": [
+        "write",
+        "read",
+        "group:create",
+        "collection:create"
+      ],
+      "resource_name": "bucket",
+      "uri": "/buckets/mybucket"
+    },
+    ...
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,7 @@ Sample result:
 
 ## Listing all resource permissions
 
-If the [`permissions_endpoint` capability](http://kinto.readthedocs.io/en/stable/api/1.x/permissions.html#list-every-permissions) available on the server, you can retrieve the list of all permissions set for the authenticated user using the `listPermissions()` method:
+If the [`permissions_endpoint` capability](http://kinto.readthedocs.io/en/stable/api/1.x/permissions.html#list-every-permissions) is installed on the server, you can retrieve the list of all permissions set for the authenticated user using the `listPermissions()` method:
 
 ```js
 client.listPermissions([options])

--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,41 @@ Sample result:
 }
 ```
 
+## Listing all resource permissions
+
+If the [`permissions_endpoint` capability](http://kinto.readthedocs.io/en/stable/api/1.x/permissions.html#list-every-permissions) available on the server, you can retrieve the list of all permissions set for the authenticated user using the `listPermissions()` method:
+
+```js
+client.listPermissions([options])
+  .then(result => ...);
+```
+
+Sample result:
+
+```js
+{
+    "data": [
+        {
+            "bucket_id": "mybucket",
+            "id": "mybucket",
+            "permissions": [
+                "write",
+                "read",
+                "group:create",
+                "collection:create"
+            ],
+            "resource_name": "bucket",
+            "uri": "/buckets/mybucket"
+        },
+        ...
+    ]
+}
+```
+
+#### Options
+
+- `headers`: Custom headers object to send along the HTTP request.
+
 ## Attachments
 
 If the [attachment](https://github.com/Kinto/kinto-attachment) capability is available from the Kinto server, you can attach files to records. Files must be passed as [data urls](http://dataurl.net/#about), which can be generated using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) in the browser.

--- a/src/base.js
+++ b/src/base.js
@@ -6,6 +6,7 @@ import endpoint from "./endpoint";
 import * as requests from "./requests";
 import { aggregate } from "./batch";
 import Bucket from "./bucket";
+import { capable } from "./utils";
 
 
 /**
@@ -431,6 +432,21 @@ export default class KintoClientBase {
       path: path + "?" + querystring,
       ...options,
     }, {raw: true}).then(handleResponse);
+  }
+
+  /**
+   * Lists all permissions.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @return {Promise<Object[], Error>}
+   */
+  @capable(["permissions_endpoint"])
+  listPermissions(options={}) {
+    return this.execute({
+      path: endpoint("permissions"),
+      headers: {...this.defaultReqOptions.headers, ...options.headers}
+    });
   }
 
   /**

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -3,15 +3,17 @@
  * @type {Object}
  */
 const ENDPOINTS = {
-  root:                   () =>
+  root: () =>
     "/",
-  batch:                  () =>
+  batch: () =>
     "/batch",
-  bucket:           (bucket) =>
+  permissions: () =>
+    "/permissions",
+  bucket: (bucket) =>
     "/buckets" + (bucket ? `/${bucket}` : ""),
   collection: (bucket, coll) =>
     `${ENDPOINTS.bucket(bucket)}/collections` + (coll ? `/${coll}` : ""),
-  group:     (bucket, group) =>
+  group: (bucket, group) =>
     `${ENDPOINTS.bucket(bucket)}/groups` + (group ? `/${group}` : ""),
   record: (bucket, coll, id) =>
     `${ENDPOINTS.collection(bucket, coll)}/records` + (id ? `/${id}` : ""),

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -700,33 +700,44 @@ describe("KintoClient", () => {
   describe("#listPermissions()", () => {
     const data = [{id: "a"}, {id: "b"}];
 
-    beforeEach(() => {
-      api.serverInfo = {capabilities: {"permissions_endpoint": {}}};
-      sandbox.stub(api, "execute").returns(Promise.resolve({data}));
-    });
+    describe("Capability available", () => {
+      beforeEach(() => {
+        api.serverInfo = {capabilities: {"permissions_endpoint": {}}};
+        sandbox.stub(api, "execute").returns(Promise.resolve({data}));
+      });
 
-    it("should execute expected request", () => {
-      api.listPermissions()
-        .then(() => {
-          sinon.assert.calledWithMatch(api.execute, {
-            path: "/permissions",
+      it("should execute expected request", () => {
+        api.listPermissions()
+          .then(() => {
+            sinon.assert.calledWithMatch(api.execute, {
+              path: "/permissions",
+            });
           });
-        });
-    });
+      });
 
-    it("should support passing custom headers", () => {
-      api.defaultReqOptions.headers = {Foo: "Bar"};
-      api.listPermissions({headers: {Baz: "Qux"}})
-        .then(() => {
-          sinon.assert.calledWithMatch(api.execute, {
-            headers: {Foo: "Bar", Baz: "Qux"}
+      it("should support passing custom headers", () => {
+        api.defaultReqOptions.headers = {Foo: "Bar"};
+        api.listPermissions({headers: {Baz: "Qux"}})
+          .then(() => {
+            sinon.assert.calledWithMatch(api.execute, {
+              headers: {Foo: "Bar", Baz: "Qux"}
+            });
           });
-        });
+      });
+
+      it("should resolve with a result object", () => {
+        return api.listPermissions()
+          .should.eventually.have.property("data").eql(data);
+      });
     });
 
-    it("should resolve with a result object", () => {
-      return api.listPermissions()
-        .should.eventually.have.property("data").eql(data);
+    describe("Capability unavailable", () => {
+      it("should reject with an error when the capability is not available", () => {
+        api.serverInfo = {capabilities: {}};
+
+        return api.listPermissions()
+          .should.be.rejectedWith(Error, /permissions_endpoint/);
+      });
     });
   });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -696,6 +696,40 @@ describe("KintoClient", () => {
     });
   });
 
+  /** @test {KintoClient#listPermissions} */
+  describe("#listPermissions()", () => {
+    const data = [{id: "a"}, {id: "b"}];
+
+    beforeEach(() => {
+      api.serverInfo = {capabilities: {"permissions_endpoint": {}}};
+      sandbox.stub(api, "execute").returns(Promise.resolve({data}));
+    });
+
+    it("should execute expected request", () => {
+      api.listPermissions()
+        .then(() => {
+          sinon.assert.calledWithMatch(api.execute, {
+            path: "/permissions",
+          });
+        });
+    });
+
+    it("should support passing custom headers", () => {
+      api.defaultReqOptions.headers = {Foo: "Bar"};
+      api.listPermissions({headers: {Baz: "Qux"}})
+        .then(() => {
+          sinon.assert.calledWithMatch(api.execute, {
+            headers: {Foo: "Bar", Baz: "Qux"}
+          });
+        });
+    });
+
+    it("should resolve with a result object", () => {
+      return api.listPermissions()
+        .should.eventually.have.property("data").eql(data);
+    });
+  });
+
   /** @test {KintoClient#listBuckets} */
   describe("#listBuckets()", () => {
     const data = [{id: "a"}, {id: "b"}];

--- a/test/endpoint_test.js
+++ b/test/endpoint_test.js
@@ -36,4 +36,9 @@ describe("endpoint()", () => {
     expect(endpoint("record", "foo", "bar", 42))
       .eql("/buckets/foo/collections/bar/records/42");
   });
+
+  it("should provide a permissions endpoint", () => {
+    expect(endpoint("permissions"))
+      .eql("/permissions");
+  });
 });

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -222,6 +222,23 @@ describe("Integration tests", function() {
       });
     });
 
+    describe("#listPermissions", () => {
+      beforeEach(() => {
+        return api.batch(batch => {
+          batch.createBucket("b1");
+          batch.bucket("b1").createCollection("c1");
+        });
+      });
+
+      it("should retrieve the list of permissions", () => {
+        return api.listPermissions()
+          .then(({data}) => {
+            expect(data).to.have.length.of(2);
+            expect(data.map(p => p.id).sort()).eql(["b1", "c1"]);
+          });
+      });
+    });
+
     describe("#listBuckets", () => {
       beforeEach(() => {
         return api.batch(batch => {

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -20,6 +20,9 @@ kinto.attachment.folder = {bucket_id}/{collection_id}
 kinto.attachment.keep_old_files = true
 kinto.attachment.base_path = /tmp
 
+# Enable permissions endpoint
+kinto.experimental_permissions_endpoint = True
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
refs #122, r=? @leplatrem 

## Listing all resource permissions

If the [`permissions_endpoint` capability](http://kinto.readthedocs.io/en/stable/api/1.x/permissions.html#list-every-permissions) is installed on the server, you can retrieve the list of all permissions set for the authenticated user using the `listPermissions()` method:

```js
client.listPermissions([options])
  .then(result => ...);
```

Sample result:

```js
{
    "data": [
        {
            "bucket_id": "mybucket",
            "id": "mybucket",
            "permissions": [
                "write",
                "read",
                "group:create",
                "collection:create"
            ],
            "resource_name": "bucket",
            "uri": "/buckets/mybucket"
        },
        ...
    ]
}
```