### PR TITLE
Allow simple checking for the existence of a next page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@ client.bucket("blog").collection("posts")
   .then(({data, next}) => {
 ```
 
-To retrieve the next page of results, you can check for the `next` property attached to the result object obtained. If a next page is available, `next` is a function, while if pagination is exhausted, `next` is `null`:
+To retrieve the next page of results, you can check for the `next` property attached to the result object obtained. If a next page is available, `next` is a function you can call to retrieve the next page of results, and becomes a `null` when pagination is exhausted:
 
 ```js
 let getNextPage;
@@ -1414,6 +1414,8 @@ if (getNextPage) {
       console.log("Page 2", data);
       getNextPage = next; // etc...
     });
+} else {
+  console.log("No more pages.")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@ client.bucket("blog").collection("posts")
   .then(({data, next}) => {
 ```
 
-To retrieve the next page of results, you can check for the `next` property attached to the result object obtained. If a next page is available, `next` is a function you can call to retrieve the next page of results, and becomes a `null` when pagination is exhausted:
+To retrieve the next page of results, you can check for the `next` property attached to the result object obtained. If a next page is available, `next` is a function you can call to retrieve the next page of results; it becomes a `null` when pagination is exhausted:
 
 ```js
 let getNextPage;

--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@ client.bucket("blog").collection("posts")
   .then(({data, next}) => {
 ```
 
-To retrieve the next page of results, just call `next()` from the result object obtained. If no next page is available, `next()` throws an error you can catch to exit the flow:
+To retrieve the next page of results, you can check for the `next` property attached to the result object obtained. If a next page is available, `next` is a function, while if pagination is exhausted, `next` is `null`:
 
 ```js
 let getNextPage;
@@ -1408,13 +1408,13 @@ client.bucket("blog").collection("posts")
 Later down the flow:
 
 ```js
-getNextPage()
-  .then(({data, next}) => {
-    console.log("Page 2", data);
-  })
-  .catch(_ => {
-    console.log("No more pages.");
-  });
+if (getNextPage) {
+  getNextPage()
+    .then(({data, next}) => {
+      console.log("Page 2", data);
+      getNextPage = next; // etc...
+    });
+}
 ```
 
 Last, if you just want to retrieve and aggregate a given number of result pages, instead of dealing with calling `next()` recursively you can simply specify the `pages` option:

--- a/src/base.js
+++ b/src/base.js
@@ -388,13 +388,6 @@ export default class KintoClientBase {
     });
     let results = [], current = 0;
 
-    const next = function(nextPage) {
-      if (!nextPage) {
-        throw new Error("Pagination exhausted.");
-      }
-      return processNextPage(nextPage);
-    };
-
     const processNextPage = (nextPage) => {
       const {headers} = options;
       return this.http.request(nextPage, {headers})
@@ -407,7 +400,7 @@ export default class KintoClientBase {
       return {
         last_modified: etag ? etag.replace(/"/g, "") : etag,
         data: results,
-        next: next.bind(null, nextPage)
+        next: nextPage ? processNextPage.bind(null, nextPage) : null,
       };
     };
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -585,9 +585,9 @@ describe("KintoClient", () => {
           .should.eventually.have.property("data").eql([{a: 1}]);
       });
 
-      it("should resolve with a next() function", () => {
+      it("should resolve with a null next property", () => {
         return api.paginatedList(path)
-          .should.eventually.have.property("next").to.be.a("function");
+          .should.eventually.have.property("next").to.be.a("null");
       });
 
       it("should support the since option", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1424,8 +1424,7 @@ describe("Integration tests", function() {
               it("should resolve with an empty array on exhausted pagination", () => {
                 return coll.listRecords({limit: 2}) // 1st page of 2 records
                   .then(res => res.next())          // 2nd page of 1 record
-                  .then(res => res.next())          // No next page
-                  .should.be.rejectedWith(Error, /Pagination exhausted./);
+                  .should.eventually.have.property("next").to.be.a("null");
               });
 
               it("should retrieve all pages", () => {


### PR DESCRIPTION
This one will probably trigger interesting discussions :)

While working on implementing support for list pagination in the kinto admin, I realized the `next()` mechanism for paginating results was flawed from a developer usability standpoint; to check if there's a next page (eg. to render a *Next page* button), one has to actually execute the function, which actually performs the HTTP request. There's obviously a valid use case where you simply want to know if there **is** a next page or not.

I have to fallback to the good old `Function | null` pattern to know if a next page is retrievable; I'm not super easy with it, but in this specific case I'm finding it simple yet quite efficient. If you have better patterns in mind to address this, feel free to mention them in the comments.

Feedback=? @leplatrem @Natim @glasserc 

**Update:** Alternative PR in #131