### PR TITLE
fix #127 - Expose the endpoint function to client programs

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -524,4 +524,15 @@ export default class KintoClientBase {
     const path = endpoint("bucket");
     return this.execute(requests.deleteRequest(path, reqOptions));
   }
+
+  /**
+   * Retrieves a server enpoint by its name.
+   *
+   * @param  {String}    name The endpoint name.
+   * @param  {...string} args The endpoint parameters.
+   * @return {String}
+   */
+  static endpoint() {
+    return endpoint.apply(undefined, arguments);
+  }
 }

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -10,6 +10,8 @@ import { SUPPORTED_PROTOCOL_VERSION as SPV } from "../src/base";
 import * as requests from "../src/requests";
 import Bucket from "../src/bucket";
 
+import endpoint from "../src/endpoint";
+
 chai.use(chaiAsPromised);
 chai.should();
 chai.config.includeStack = true;
@@ -958,6 +960,14 @@ describe("KintoClient", () => {
 
       return api.deleteBuckets()
         .should.be.rejectedWith(Error, /Version/);
+    });
+  });
+
+  /** @test {KintoClient#endpoint} */
+  describe("#endpoint()", () => {
+    it("should forward calls to endpoint", () => {
+      return KintoClient.endpoint("root")
+        .should.equal(endpoint("root"));
     });
   });
 });


### PR DESCRIPTION
I've created a test, but the endpoint function can't be stubbed AFAICT, so I've compared one output.
Coverage should be good.
I've not kept the `(name, ...args)` arguments, because the generated code is silly: deconstructs and constructs again the `arguments`.