### PR TITLE
Fix #135: Allow retrieval of collection total number of records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,15 +1085,16 @@ Sample result:
 }
 ```
 
-> #### Notes
->
->- The root `last_modified` value, which is the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see the *Options* section below).
->- The `next` function, which helps [paginating results](#paginating-results).
->- The `totalRecords` property, which holds the total number of records in the entire collection. This number can alternatively be retrieved using the `getTotalRecords()` collection method.
+The result object exposes the following properties:
+
+- `last_modified`: the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see [Generic bucket and collection options](#generic-bucket-and-collection-options)).
+- `next`: the [pagination](#paginating-results) helper to access the next page of results, if any.
+- `totalRecords`: the total number of records in the **entire collection**. This number can alternatively be retrieved using the `getTotalRecords()` method of the collection API.
+- `data`: the list of records.
 
 #### Options
 
-- `headers`: Custom headers object to send along the HTTP request;
+- `headers`: Custom headers object to send along the HTTP request.
 
 This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
 

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Sample result:
 {
   last_modified: "1456183930780",
   next: <Function>,
+  totalRecords: 2,
   data: [
     {
       "content": "True.",
@@ -1084,7 +1085,11 @@ Sample result:
 }
 ```
 
-Note the root `last_modified` value which is the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see the *Options* section below).
+> #### Notes
+>
+>- The root `last_modified` value, which is the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see the *Options* section below).
+>- The `next` function, which helps [paginating results](#paginating-results).
+>- The `totalRecords` property, which holds the total number of records in the entire collection. This number can alternatively be retrieved using the `getTotalRecords()` collection method.
 
 #### Options
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -75,7 +75,7 @@ export default class Collection {
   }
 
   /**
-   * Retrieves the total number of record sin this collection.
+   * Retrieves the total number of records in this collection.
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.

--- a/src/collection.js
+++ b/src/collection.js
@@ -75,6 +75,23 @@ export default class Collection {
   }
 
   /**
+   * Retrieves the total number of record sin this collection.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @return {Promise<Number, Error>} [description]
+   */
+  getTotalRecords(options={}) {
+    const { headers } = this._collOptions(options);
+    return this.client.execute({
+      method: "HEAD",
+      path: endpoint("record", this.bucket.name, this.name),
+      headers
+    }, {raw: true})
+      .then(({headers}) => parseInt(headers.get("Total-Records"), 10));
+  }
+
+  /**
    * Retrieves collection data.
    *
    * @param  {Object} [options={}]      The options object.

--- a/src/collection.js
+++ b/src/collection.js
@@ -79,7 +79,7 @@ export default class Collection {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
-   * @return {Promise<Number, Error>} [description]
+   * @return {Promise<Number, Error>}
    */
   getTotalRecords(options={}) {
     const { headers } = this._collOptions(options);

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -543,6 +543,7 @@ describe("KintoClient", () => {
   /** @test {KintoClient#paginatedList} */
   describe("#paginatedList()", () => {
     const ETag = "\"42\"";
+    const totalRecords = 1337;
     const path = "/some/path";
 
     describe("No pagination", () => {
@@ -554,6 +555,8 @@ describe("KintoClient", () => {
             get: (name) => {
               if (name === "ETag") {
                 return ETag;
+              } else if (name === "Total-Records") {
+                return String(totalRecords);
               }
             }
           }
@@ -583,6 +586,11 @@ describe("KintoClient", () => {
       it("should resolve with records list", () => {
         return api.paginatedList(path)
           .should.eventually.have.property("data").eql([{a: 1}]);
+      });
+
+      it("should resolve with number of total records", () => {
+        return api.paginatedList(path)
+          .should.eventually.have.property("totalRecords").eql(1337);
       });
 
       it("should resolve with a next() function", () => {
@@ -714,6 +722,23 @@ describe("KintoClient", () => {
 
         return api.paginatedList(path)
           .should.eventually.have.property("hasNextPage").eql(true);
+      });
+
+      it("should resolve with number of total records", () => {
+        const { http } = api;
+        sandbox.stub(http, "request")
+          // settings retrieval
+          .onFirstCall().returns(Promise.resolve({
+            json: {settings: {}}
+          }))
+          // first page
+          .onSecondCall().returns(Promise.resolve({
+            headers: {get: () => "1337"},
+            json: {data: [1, 2]}
+          }));
+
+        return api.paginatedList(path)
+          .should.eventually.have.property("totalRecords").eql(1337);
       });
     });
 

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -34,6 +34,28 @@ describe("Collection", () => {
     return new Bucket(client, "blog").collection("posts", options);
   }
 
+  /** @test {Collection#getTotalRecords} */
+  describe("#getTotalRecords()", () => {
+    it("should execute expected request", () => {
+      sandbox.stub(client, "execute").returns(Promise.resolve());
+
+      getBlogPostsCollection().getTotalRecords();
+
+      sinon.assert.calledWithMatch(client.execute, {
+        method: "HEAD",
+        path: "/buckets/blog/collections/posts/records",
+      }, {raw: true});
+    });
+
+    it("should resolve with the Total-Records header value", () => {
+      sandbox.stub(client, "execute")
+        .returns(Promise.resolve({headers: {get() {return 42;}}}));
+
+      return getBlogPostsCollection().getTotalRecords()
+        .should.become(42);
+    });
+  });
+
   /** @test {Collection#getData} */
   describe("#getData()", () => {
     it("should execute expected request", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1061,6 +1061,22 @@ describe("Integration tests", function() {
             return collPromise().then(_coll => coll = _coll);
           });
 
+          describe(".getTotalRecords()", () => {
+            it("should retrieve the initial total number of records", () => {
+              return coll.getTotalRecords()
+                .should.become(0);
+            });
+
+            it("should retrieve the updated total number of records", () => {
+              return coll.batch(batch => {
+                batch.createRecord({a: 1});
+                batch.createRecord({a: 2});
+              })
+                .then(() => coll.getTotalRecords())
+                .should.become(2);
+            });
+          });
+
           describe(".getPermissions()", () => {
             it("should retrieve permissions", () => {
               return coll.getPermissions()
@@ -1335,6 +1351,13 @@ describe("Integration tests", function() {
                 .then(_ => coll.listRecords())
                 .then(({data}) => data.map(record => record.title))
                 .should.become(["foo"]);
+            });
+
+            it("should expose the total number of records", () => {
+              return  coll.createRecord({a: 1})
+                .then(() => coll.createRecord({a: 2}))
+                .then(() => coll.listRecords())
+                .should.eventually.have.property("totalRecords").eql(2);
             });
 
             it("should order records by field", () => {


### PR DESCRIPTION
Refs #135. r=? @Natim  @glasserc 

### Listing records

```js
client.bucket("blog").collection("posts")
  .listRecords()
  .then(result => ...);
```

Sample result:

```js
{
  last_modified: "1456183930780",
  next: <Function>,
  totalRecords: 2,
  data: [
    {
      "content": "True.",
      "last_modified": 1456183930780,
      "id": "a89dd4b2-d597-4192-bc2b-834116244d29",
      "title": "I love cheese"
    },
    {
      "content": "Yo",
      "last_modified": 1456183914275,
      "id": "63c1805a-565a-46cc-bfb3-007dfad54065",
      "title": "Another post"
    }
  ]
}
```

The result object exposes the following properties:

- `last_modified`: the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see [Generic bucket and collection options](#generic-bucket-and-collection-options)).
- `next`: the [pagination](#paginating-results) helper to access the next page of results, if any.
- `totalRecords`: the total number of records in the **entire collection**. This number can alternatively be retrieved using the `getTotalRecords()` method of the collection API.
- `data`: the list of records.