### PR TITLE
Improve HTTP 412 error message.

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -13,7 +13,7 @@ export default {
   111: "Missing Token / id",
   112: "Content-Length header was not provided",
   113: "Request body too large",
-  114: "Resource was modified meanwhile",
+  114: "Resource was created, updated or deleted meanwhile",
   115: "Method not allowed on this end point (hint: server may be readonly)",
   116: "Requested version not available on this server",
   117: "Client has sent too many requests",


### PR DESCRIPTION
This slightly improves the error message attached to a 412 error response. The old one was accurate but could be misleading. 

r=? @Natim 