### PR TITLE
Remove polyfill from module dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build:readme": "./node_modules/.bin/toctoc -w -d 2 README.md",
     "dist": "mkdir -p dist && rm -f dist/*.* && npm run dist-dev && npm run dist-prod && npm run dist-noshim && npm run dist-fx",
     "dist-dev": "browserify -s KintoClient -d -e src/index.js -o dist/kinto-http.js -t [ babelify --sourceMapRelative . ]",
-    "dist-noshim": "browserify -s KintoClient -g uglifyify --ignore isomorphic-fetch --ignore babel-polyfill -e src/index.js -o dist/kinto-http.noshim.js -t [ babelify --sourceMapRelative . ]",
+    "dist-noshim": "browserify -s KintoClient -g uglifyify --ignore babel-polyfill -e src/index.js -o dist/kinto-http.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s KintoClient -g uglifyify -e src/index.js -o dist/kinto-http.min.js -t [ babelify --sourceMapRelative . ]",
-    "dist-fx": "BABEL_ENV=firefox browserify -s KintoHttpClient --ignore isomorphic-fetch --ignore events --bare -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-http-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-http-client.js && cat temp.jsm >> dist/moz-kinto-http-client.js && rm temp.jsm",
+    "dist-fx": "BABEL_ENV=firefox browserify -s KintoHttpClient --ignore events --bare -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-http-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-http-client.js && cat temp.jsm >> dist/moz-kinto-http-client.js && rm temp.jsm",
     "prepublish": "npm run build:readme",
     "publish-to-npm": "npm run build && npm run dist && npm publish",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",
@@ -38,7 +38,6 @@
   },
   "homepage": "https://github.com/Kinto/kinto-http.js#readme",
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
@@ -64,6 +63,7 @@
     "esdoc-importpath-plugin": "0.0.1",
     "eslint": "2.2.0",
     "form-data": "^1.0.0-rc4",
+    "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.4.1",
     "kinto-node-test-server": "0.0.1",
     "mocha": "^2.3.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-import "isomorphic-fetch";
 import { EventEmitter } from "events";
 
 import KintoClientBase from "./base";


### PR DESCRIPTION
I don't think we should require polyfills in the code.

Users should use a polyfill service if needed, like https://cdn.polyfill.io/v2/docs/features/