### PR TITLE
Add support for a 'at' collection listRecords filter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,19 @@
-language:
-- node_js
-- python
-node_js:
-- "6"
+language: python
 python:
-- "3.5"
+ - "3.5"
 env:
-- SERVER=5.3.5 ACTION=test
-- SERVER=development ACTION=test
 - ACTION="run lint"
-- ACTION="run dist"       # ensures building dist files doesn't break
+- ACTION="run dist" # ensures building dist files doesn't break
 before_install:
 - export PATH=$HOME/.local/bin:$PATH
-- pip install --user virtualenv
-- virtualenv .env
-- if [[ $SERVER && $SERVER != development ]]; then .env/bin/pip install kinto==$SERVER; fi
-- if [[ $SERVER && $SERVER == development ]]; then .env/bin/pip install https://github.com/Kinto/kinto/zipball/master; fi
-- .env/bin/pip install kinto-attachment
+- wget https://raw.githubusercontent.com/creationix/nvm/v0.33.0/nvm.sh -O ~/.nvm/nvm.sh
+- source ~/.nvm/nvm.sh
+- nvm install 6 # for Node v6
+- node --version
+- npm install
+- curl https://raw.githubusercontent.com/Kinto/kinto/master/requirements.txt > versions.txt
+- pip install https://github.com/Kinto/kinto/zipball/master --constraint versions.txt
+- pip install kinto-attachment
 - export KINTO_PSERVE_EXECUTABLE=.env/bin/pserve
 script:
 - npm $ACTION

--- a/README.md
+++ b/README.md
@@ -1130,6 +1130,7 @@ The result object exposes the following properties:
 
 - `headers`: Custom headers object to send along the HTTP request
 - `retry`: Number of retries when request fails (default: 0)
+- `at`: Retrieve the records list at at a given timestamp back in time (note: full list is always returned, this option doesn't support pagination.)
 
 This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
 

--- a/src/base.js
+++ b/src/base.js
@@ -434,7 +434,6 @@ export default class KintoClientBase {
       // Follow next page
       return processNextPage(nextPage);
     };
-
     return this.execute({
       path: path + "?" + querystring,
       ...options,

--- a/src/collection.js
+++ b/src/collection.js
@@ -361,7 +361,7 @@ export default class Collection {
           }
         }
         return {
-          last_modified: Math.max.apply(null, snapshot.map(r => r.last_modified)),
+          last_modified: String(at),
           data: snapshot.sort((a, b) => b.last_modified - a.last_modified),
           next: () => { throw new Error("Snapshots don't support pagination"); },
           hasNextPage: false,

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1452,7 +1452,7 @@ describe("Integration tests", function() {
                   .then((result) => {
                     const expectedSnapshot = [rec3, rec2, rec1];
                     expect(result.data).to.eql(expectedSnapshot);
-                    expect(result.last_modified).eql(rec3.last_modified);
+                    expect(result.last_modified).eql(String(rec3.last_modified));
                     expect(result.hasNextPage).eql(false);
                     expect(result.totalRecords).eql(expectedSnapshot.length);
                     expect(() => result.next()).to.Throw(Error, /pagination/);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1455,25 +1455,23 @@ describe("Integration tests", function() {
               });
 
               it("should handle updates", () => {
-                let updated;
+                let updatedRec2;
                 return coll.updateRecord({...rec2, n: 42})
                   .then(({data}) => {
-                    updated = data;
-                    return coll.listRecords({at: updated.last_modified});
+                    updatedRec2 = data;
+                    return coll.listRecords({at: updatedRec2.last_modified});
                   })
                   .then((snapshot) => expect(snapshot).eql([
-                    {...rec2, n: 42, last_modified: updated.last_modified},
+                    updatedRec2,
                     rec3,
                     rec1,
                   ]));
               });
 
               it("should handle deletions", () => {
-                let deleted;
                 return coll.deleteRecord(rec1.id)
-                  .then(({data}) => {
-                    deleted = data;
-                    return coll.listRecords({at: deleted.last_modified});
+                  .then(({data: {last_modified}}) => {
+                    return coll.listRecords({at: last_modified});
                   })
                   .then((snapshot) => expect(snapshot).eql([
                     rec3,

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1407,7 +1407,7 @@ describe("Integration tests", function() {
               });
             });
 
-            describe("Changes", () => {
+            describe("since", () => {
               let ts1, ts2;
 
               beforeEach(() => {
@@ -1427,6 +1427,58 @@ describe("Integration tests", function() {
               it("should only list changes made after the provided timestamp", () => {
                 return coll.listRecords({since: ts2})
                   .should.eventually.have.property("data").to.have.length.of(1);
+              });
+            });
+
+            describe("'at' retrieves a snapshot at a given timestam", () => {
+              let rec1, rec2, rec3;
+
+              beforeEach(() => {
+                return coll.listRecords()
+                  .then(_ => coll.createRecord({n: 1}))
+                  .then(({data}) => {
+                    rec1 = data;
+                    return coll.createRecord({n: 2});
+                  })
+                  .then(({data}) => {
+                    rec2 = data;
+                    return coll.createRecord({n: 3});
+                  })
+                  .then(({data}) => rec3 = data);
+              });
+
+              it("should handle creations", () => {
+                return coll.listRecords({at: rec1.last_modified})
+                  .should.eventually.become([
+                    rec1
+                  ]);
+              });
+
+              it("should handle updates", () => {
+                let updated;
+                return coll.updateRecord({...rec2, n: 42})
+                  .then(({data}) => {
+                    updated = data;
+                    return coll.listRecords({at: updated.last_modified});
+                  })
+                  .then((snapshot) => expect(snapshot).eql([
+                    {...rec2, n: 42, last_modified: updated.last_modified},
+                    rec3,
+                    rec1,
+                  ]));
+              });
+
+              it("should handle deletions", () => {
+                let deleted;
+                return coll.deleteRecord(rec1.id)
+                  .then(({data}) => {
+                    deleted = data;
+                    return coll.listRecords({at: deleted.last_modified});
+                  })
+                  .then((snapshot) => expect(snapshot).eql([
+                    rec3,
+                    rec2,
+                  ]));
               });
             });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1504,10 +1504,6 @@ describe("Integration tests", function() {
                   .should.eventually.have.property("data")
                                     .to.length.of(54);
               });
-
-              after(() => {
-                console.log(server.logs.toString());
-              });
             });
 
             describe("Pagination", () => {

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -24,6 +24,8 @@ kinto.attachment.base_path = /tmp
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
 
+kinto.paginate_by = 10
+
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0


### PR DESCRIPTION
This adds a new `at` option to `Collection#listRecords` to retrieve a snapshot of the collection records at a given timestamp in the past.

- [x] Compute collection list of records state at a given timestamp back in time
- [x] Ensure paginating long lists of changes
- [x] Update documentation
- [ ] Fix travis build setup

f=? @leplatrem 