### PR TITLE
esdoc: remove esdoc-es7-plugin

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -5,6 +5,16 @@
     "type": "mocha",
     "source": "./test"
   },
+  "experimentalProposal": {
+    "classProperties": true,
+    "objectRestSpread": true,
+    "decorators": true,
+    "doExpressions": true,
+    "functionBind": true,
+    "asyncGenerators": true,
+    "exportExtensions": true,
+    "dynamicImport": true
+  },
   "plugins": [
     {
       "name": "esdoc-importpath-plugin",
@@ -13,9 +23,6 @@
           {"from": "^src", "to": "lib"}
         ]
       }
-    },
-    {
-      "name": "esdoc-es7-plugin"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.16",
     "esdoc": "^0.5.2",
-    "esdoc-es7-plugin": "0.0.3",
     "esdoc-importpath-plugin": "0.1.0",
     "eslint": "3.15.0",
     "form-data": "^2.1.2",

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -14,6 +14,7 @@ kinto.bucket_read_principals = system.Authenticated
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
+                 kinto.plugins.flush
 
 # Kinto-attachment
 kinto.attachment.base_url = http://0.0.0.0:8888/attachments


### PR DESCRIPTION
Per https://github.com/esdoc/esdoc/issues/390, esdoc-es7-plugin is
deprecated and esdoc has itself grown functionality equivalent to
it. Now using esdoc-es7-plugin causes esdoc generation to fail.

Following the fix in the linked issue, just turn on all the options,
since I'm not sure which ones we use specifically.

Thanks tiberiuichim for reporting this issue on Slack.