### PR TITLE
Install git precommit hook for linting and formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist-noshim": "browserify -s KintoClient -g uglifyify --ignore babel-polyfill -e src/index.js -o dist/kinto-http.noshim.js -t [ babelify --sourceMapRelative . ]",
     "dist-prod": "browserify -s KintoClient -g uglifyify -e src/index.js -o dist/kinto-http.min.js -t [ babelify --sourceMapRelative . ]",
     "dist-fx": "BABEL_ENV=firefox browserify -s KintoHttpClient --ignore events --bare -e fx-src/index.js -o temp.jsm -t [ babelify --sourceMapRelative . ] && mkdir -p dist && cp fx-src/jsm_prefix.js dist/moz-kinto-http-client.js && echo \"\n/*\n * Version $npm_package_version - $(git rev-parse --short HEAD)\n */\n\" >> dist/moz-kinto-http-client.js && cat temp.jsm >> dist/moz-kinto-http-client.js && rm temp.jsm",
+    "precommit": "lint-staged",
     "prepublish": "npm run build:readme",
     "publish-to-npm": "npm run build && npm run dist && npm publish",
     "report-coverage": "npm run test-cover && ./node_modules/coveralls/bin/coveralls.js < ./coverage/lcov.info",
@@ -23,7 +24,14 @@
     "test-nocover": "babel-node node_modules/.bin/_mocha --require ./test/setup-jsdom.js 'test/**/*_test.js'",
     "lint": "eslint src test"
   },
-  "prettierOptions": "--print-width 80 --trailing-comma es5",
+  "prettierOptions": "--trailing-comma es5",
+  "lint-staged": {
+    "{src,test}/**/*.js": [
+      "npm run lint",
+      "npm run cs-format",
+      "git add"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kinto/kinto-http.js.git"
@@ -65,9 +73,11 @@
     "esdoc-importpath-plugin": "0.1.0",
     "eslint": "3.15.0",
     "form-data": "^2.1.2",
+    "husky": "^0.13.2",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^9.10.0",
     "kinto-node-test-server": "^1.0.0",
+    "lint-staged": "^3.3.2",
     "mocha": "^3.2.0",
     "prettier": "^0.22.0",
     "prettier-check": "^1.0.0",


### PR DESCRIPTION
This installs a git precommit hook for linting and formatting code against prettier configuration. 

![tmp](https://cloud.githubusercontent.com/assets/41547/23850835/60ab46ea-07e1-11e7-8444-ff246f1e23b6.gif)