### PR TITLE
Check for snapshot history data availability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,7 +1153,7 @@ The result object exposes the following properties:
 
 - `headers`: Custom headers object to send along the HTTP request
 - `retry`: Number of retries when request fails (default: 0)
-- `at`: Retrieve the records list at at a given timestamp back in time (note: full list is always returned, this option doesn't support pagination.)
+- `at`: Retrieve the records list at at a given timestamp back in time (note: full list is always returned, this option doesn't support pagination and will reject if the [History plugin](http://kinto.readthedocs.io/en/stable/api/1.x/history.html) isn't enabled or has been enabled after the creation of the collection.)
 
 This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -361,7 +361,7 @@ export default class Collection {
     });
     return oldestHistoryEntry
       ? oldestHistoryEntry.target.data.last_modified
-      : 0;
+      : null;
   }
 
   /**
@@ -389,7 +389,9 @@ export default class Collection {
     }
     // If history doesn't have enough data, reject with an error
     const oldestHistory = await this.findHistoryOldestTimestamp();
-    if (oldestHistory > at) {
+    if (!oldestHistory) {
+      throw new Error("History is not enabled.");
+    } else if (oldestHistory > at) {
       throw new Error(
         [
           "Not enough history data; history for this collection",

--- a/src/collection.js
+++ b/src/collection.js
@@ -357,8 +357,15 @@ export default class Collection {
     let oldestRecord;
     // First, check that the history plugin covers the entire range back to the
     // requested timestamp.
-    // 1. find the oldest record timestamp in the current collection
-    return this.listRecords({ sort: "last_modified", limit: 1 })
+    // 1. find the record timestamp in the current collection which
+    // last_modified is immediately fresher than the requested timestamp.
+    return this.listRecords({
+      sort: "last_modified",
+      limit: 1,
+      filters: {
+        min_last_modified: String(at),
+      },
+    })
       .then(({ data: [_oldestRecord] }) => {
         if (!_oldestRecord) {
           // If the current records list is empty, we can't find its oldest

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1744,7 +1744,9 @@ describe("Integration tests", function() {
                   .updateRecord({ ...rec2, n: 42 })
                   .then(({ data }) => {
                     updatedRec2 = data;
-                    return coll.listRecords({ at: updatedRec2.last_modified });
+                    return coll.listRecords({
+                      at: updatedRec2.last_modified,
+                    });
                   })
                   .then(({ data }) => {
                     expect(data).eql([updatedRec2, rec3, rec1]);

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1744,9 +1744,7 @@ describe("Integration tests", function() {
                   .updateRecord({ ...rec2, n: 42 })
                   .then(({ data }) => {
                     updatedRec2 = data;
-                    return coll.listRecords({
-                      at: updatedRec2.last_modified,
-                    });
+                    return coll.listRecords({ at: updatedRec2.last_modified });
                   })
                   .then(({ data }) => {
                     expect(data).eql([updatedRec2, rec3, rec1]);


### PR DESCRIPTION
This adds checks to ensure we dispose of all the history required to compute a snapshot back to requested timestamp.

Refs https://github.com/Kinto/kinto-admin/issues/402