### PR TITLE
Async await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
       "plugins": [
         "babel-plugin-transform-decorators-legacy",
         "transform-object-rest-spread",
+        "transform-async-to-generator"
       ]
     },
     "firefox": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-eslint": "^7.1.1",
     "babel-istanbul": "^0.12.1",
     "babel-loader": "^6.2.10",
+    "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",

--- a/src/base.js
+++ b/src/base.js
@@ -288,7 +288,7 @@ export default class KintoClientBase {
     const maxRequests = serverSettings["batch_max_requests"];
     if (maxRequests && requests.length > maxRequests) {
       const chunks = partition(requests, maxRequests);
-      return await pMap(chunks, chunk => this._batchRequests(chunk, options));
+      return pMap(chunks, chunk => this._batchRequests(chunk, options));
     }
     const { responses } = await this.execute({
       ...reqOptions,
@@ -395,7 +395,7 @@ export default class KintoClientBase {
       if (!nextPage) {
         throw new Error("Pagination exhausted.");
       }
-      return await processNextPage(nextPage);
+      return processNextPage(nextPage);
     };
 
     const processNextPage = async function(nextPage) {
@@ -431,7 +431,7 @@ export default class KintoClientBase {
         return pageResults(results, nextPage, etag, totalRecords);
       }
       // Follow next page
-      return await processNextPage(nextPage);
+      return processNextPage(nextPage);
     };
 
     return handleResponse(
@@ -456,7 +456,7 @@ export default class KintoClientBase {
     // Ensure the default sort parameter is something that exists in permissions
     // entries, as `last_modified` doesn't; here, we pick "id".
     const paginationOptions = { sort: "id", ...options };
-    return await this.paginatedList(path, paginationOptions, reqOptions);
+    return this.paginatedList(path, paginationOptions, reqOptions);
   }
 
   /**
@@ -469,7 +469,7 @@ export default class KintoClientBase {
   async listBuckets(options = {}) {
     const path = endpoint("bucket");
     const reqOptions = this._getRequestOptions(options);
-    return await this.paginatedList(path, options, reqOptions);
+    return this.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -489,7 +489,7 @@ export default class KintoClientBase {
       data.id = id;
     }
     const path = data.id ? endpoint("bucket", data.id) : endpoint("bucket");
-    return await this.execute(
+    return this.execute(
       requests.createRequest(path, { data, permissions }, reqOptions)
     );
   }
@@ -513,7 +513,7 @@ export default class KintoClientBase {
     const path = endpoint("bucket", bucketObj.id);
     const { last_modified } = { bucketObj };
     const reqOptions = this._getRequestOptions({ last_modified, ...options });
-    return await this.execute(requests.deleteRequest(path, reqOptions));
+    return this.execute(requests.deleteRequest(path, reqOptions));
   }
 
   /**
@@ -530,6 +530,6 @@ export default class KintoClientBase {
   async deleteBuckets(options = {}) {
     const reqOptions = this._getRequestOptions(options);
     const path = endpoint("bucket");
-    return await this.execute(requests.deleteRequest(path, reqOptions));
+    return this.execute(requests.deleteRequest(path, reqOptions));
   }
 }

--- a/src/base.js
+++ b/src/base.js
@@ -211,17 +211,15 @@ export default class KintoClientBase {
    * @param  {Object}  [options={}] The request options.
    * @return {Promise<Object, Error>}
    */
-  fetchServerInfo(options = {}) {
+  async fetchServerInfo(options = {}) {
     if (this.serverInfo) {
-      return Promise.resolve(this.serverInfo);
-    }
-    const reqOptions = this._getRequestOptions(options);
-    return this.http.request(this.remote + endpoint("root"), reqOptions).then(({
-      json,
-    }) => {
-      this.serverInfo = json;
       return this.serverInfo;
-    });
+    }
+    const path = this.remote + endpoint("root");
+    const reqOptions = this._getRequestOptions(options);
+    const { json } = await this.http.request(path, reqOptions);
+    this.serverInfo = json;
+    return this.serverInfo;
   }
 
   /**
@@ -231,8 +229,9 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
-  fetchServerSettings(options = {}) {
-    return this.fetchServerInfo(options).then(({ settings }) => settings);
+  async fetchServerSettings(options = {}) {
+    const { settings } = await this.fetchServerInfo(options);
+    return settings;
   }
 
   /**
@@ -242,10 +241,9 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
-  fetchServerCapabilities(options = {}) {
-    return this.fetchServerInfo(options).then(
-      ({ capabilities }) => capabilities
-    );
+  async fetchServerCapabilities(options = {}) {
+    const { capabilities } = await this.fetchServerInfo(options);
+    return capabilities;
   }
 
   /**
@@ -255,8 +253,9 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
-  fetchUser(options = {}) {
-    return this.fetchServerInfo(options).then(({ user }) => user);
+  async fetchUser(options = {}) {
+    const { user } = await this.fetchServerInfo(options);
+    return user;
   }
 
   /**
@@ -266,10 +265,9 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
-  fetchHTTPApiVersion(options = {}) {
-    return this.fetchServerInfo(options).then(({ http_api_version }) => {
-      return http_api_version;
-    });
+  async fetchHTTPApiVersion(options = {}) {
+    const { http_api_version } = await this.fetchServerInfo(options);
+    return http_api_version;
   }
 
   /**
@@ -280,28 +278,28 @@ export default class KintoClientBase {
    * @param  {Object} [options={}] The options object.
    * @return {Promise<Object, Error>}
    */
-  _batchRequests(requests, options = {}) {
+  async _batchRequests(requests, options = {}) {
     const reqOptions = this._getRequestOptions(options);
     const { headers } = reqOptions;
     if (!requests.length) {
-      return Promise.resolve([]);
+      return [];
     }
-    return this.fetchServerSettings().then(serverSettings => {
-      const maxRequests = serverSettings["batch_max_requests"];
-      if (maxRequests && requests.length > maxRequests) {
-        const chunks = partition(requests, maxRequests);
-        return pMap(chunks, chunk => this._batchRequests(chunk, options));
-      }
-      return this.execute({
-        ...reqOptions,
-        path: endpoint("batch"),
-        method: "POST",
-        body: {
-          defaults: { headers },
-          requests: requests,
-        },
-      }).then(({ responses }) => responses); // we only care about the responses
+    const serverSettings = await this.fetchServerSettings();
+    const maxRequests = serverSettings["batch_max_requests"];
+    if (maxRequests && requests.length > maxRequests) {
+      const chunks = partition(requests, maxRequests);
+      return await pMap(chunks, chunk => this._batchRequests(chunk, options));
+    }
+    const { responses } = await this.execute({
+      ...reqOptions,
+      path: endpoint("batch"),
+      method: "POST",
+      body: {
+        defaults: { headers },
+        requests: requests,
+      },
     });
+    return responses;
   }
 
   /**
@@ -320,7 +318,7 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @nobatch("Can't use batch within a batch!")
-  batch(fn, options = {}) {
+  async batch(fn, options = {}) {
     const rootBatch = new KintoClientBase(this.remote, {
       ...this._options,
       ...this._getRequestOptions(options),
@@ -334,17 +332,13 @@ export default class KintoClientBase {
       }
     }
     const batchClient = collBatch || bucketBatch || rootBatch;
-    try {
-      fn(batchClient);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return this._batchRequests(rootBatch._requests, options).then(responses => {
-      if (options.aggregate) {
-        return aggregate(responses, rootBatch._requests);
-      }
+    fn(batchClient);
+    const responses = await this._batchRequests(rootBatch._requests, options);
+    if (options.aggregate) {
+      return aggregate(responses, rootBatch._requests);
+    } else {
       return responses;
-    });
+    }
   }
 
   /**
@@ -358,7 +352,7 @@ export default class KintoClientBase {
    * JSON.
    * @return {Promise<Object, Error>}
    */
-  execute(request, options = { raw: false, stringify: true }) {
+  async execute(request, options = { raw: false, stringify: true }) {
     const { raw, stringify } = options;
     // If we're within a batch, add the request to the stack to send at once.
     if (this._isBatch) {
@@ -367,18 +361,17 @@ export default class KintoClientBase {
       // from within a batch operation.
       const msg = "This result is generated from within a batch " +
         "operation and should not be consumed.";
-      return Promise.resolve(raw ? { json: msg, headers: { get() {} } } : msg);
+      return raw ? { json: msg, headers: { get() {} } } : msg;
     }
-    const promise = this.fetchServerSettings().then(_ => {
-      return this.http.request(this.remote + request.path, {
-        ...request,
-        body: stringify ? JSON.stringify(request.body) : request.body,
-      });
+    await this.fetchServerSettings();
+    const result = await this.http.request(this.remote + request.path, {
+      ...request,
+      body: stringify ? JSON.stringify(request.body) : request.body,
     });
-    return raw ? promise : promise.then(({ json }) => json);
+    return raw ? result : result.json;
   }
 
-  paginatedList(path, params, options = {}) {
+  async paginatedList(path, params, options = {}) {
     const { sort, filters, limit, pages, since } = {
       sort: "-last_modified",
       ...params,
@@ -398,17 +391,17 @@ export default class KintoClientBase {
     });
     let results = [], current = 0;
 
-    const next = function(nextPage) {
+    const next = async function(nextPage) {
       if (!nextPage) {
         throw new Error("Pagination exhausted.");
       }
-      return processNextPage(nextPage);
+      return await processNextPage(nextPage);
     };
 
-    const processNextPage = nextPage => {
+    const processNextPage = async function(nextPage) {
       const { headers } = options;
-      return this.http.request(nextPage, { headers }).then(handleResponse);
-    };
+      return handleResponse(await this.http.request(nextPage, { headers }));
+    }.bind(this);
 
     const pageResults = (results, nextPage, etag, totalRecords) => {
       // ETag string is supposed to be opaque and stored «as-is».
@@ -422,7 +415,7 @@ export default class KintoClientBase {
       };
     };
 
-    const handleResponse = ({ headers, json }) => {
+    const handleResponse = async function({ headers, json }) {
       const nextPage = headers.get("Next-Page");
       const etag = headers.get("ETag");
       const totalRecords = parseInt(headers.get("Total-Records"), 10);
@@ -438,12 +431,15 @@ export default class KintoClientBase {
         return pageResults(results, nextPage, etag, totalRecords);
       }
       // Follow next page
-      return processNextPage(nextPage);
+      return await processNextPage(nextPage);
     };
-    return this.execute(
-      { path: path + "?" + querystring, ...options },
-      { raw: true }
-    ).then(handleResponse);
+
+    return handleResponse(
+      await this.execute(
+        { path: path + "?" + querystring, ...options },
+        { raw: true }
+      )
+    );
   }
 
   /**
@@ -454,13 +450,13 @@ export default class KintoClientBase {
    * @return {Promise<Object[], Error>}
    */
   @capable(["permissions_endpoint"])
-  listPermissions(options = {}) {
+  async listPermissions(options = {}) {
     const path = endpoint("permissions");
     const reqOptions = this._getRequestOptions(options);
     // Ensure the default sort parameter is something that exists in permissions
     // entries, as `last_modified` doesn't; here, we pick "id".
     const paginationOptions = { sort: "id", ...options };
-    return this.paginatedList(path, paginationOptions, reqOptions);
+    return await this.paginatedList(path, paginationOptions, reqOptions);
   }
 
   /**
@@ -470,10 +466,10 @@ export default class KintoClientBase {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object[], Error>}
    */
-  listBuckets(options = {}) {
+  async listBuckets(options = {}) {
     const path = endpoint("bucket");
     const reqOptions = this._getRequestOptions(options);
-    return this.paginatedList(path, options, reqOptions);
+    return await this.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -486,14 +482,14 @@ export default class KintoClientBase {
    * @param  {Object}       [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  createBucket(id, options = {}) {
+  async createBucket(id, options = {}) {
     const reqOptions = this._getRequestOptions(options);
     const { data = {}, permissions } = reqOptions;
     if (id != null) {
       data.id = id;
     }
     const path = data.id ? endpoint("bucket", data.id) : endpoint("bucket");
-    return this.execute(
+    return await this.execute(
       requests.createRequest(path, { data, permissions }, reqOptions)
     );
   }
@@ -509,7 +505,7 @@ export default class KintoClientBase {
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  deleteBucket(bucket, options = {}) {
+  async deleteBucket(bucket, options = {}) {
     const bucketObj = toDataBody(bucket);
     if (!bucketObj.id) {
       throw new Error("A bucket id is required.");
@@ -517,7 +513,7 @@ export default class KintoClientBase {
     const path = endpoint("bucket", bucketObj.id);
     const { last_modified } = { bucketObj };
     const reqOptions = this._getRequestOptions({ last_modified, ...options });
-    return this.execute(requests.deleteRequest(path, reqOptions));
+    return await this.execute(requests.deleteRequest(path, reqOptions));
   }
 
   /**
@@ -531,9 +527,9 @@ export default class KintoClientBase {
    * @return {Promise<Object, Error>}
    */
   @support("1.4", "2.0")
-  deleteBuckets(options = {}) {
+  async deleteBuckets(options = {}) {
     const reqOptions = this._getRequestOptions(options);
     const path = endpoint("bucket");
-    return this.execute(requests.deleteRequest(path, reqOptions));
+    return await this.execute(requests.deleteRequest(path, reqOptions));
   }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -85,10 +85,11 @@ export default class Bucket {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getData(options = {}) {
+  async getData(options = {}) {
     const reqOptions = { ...this._bucketOptions(options) };
     const request = { ...reqOptions, path: endpoint("bucket", this.name) };
-    return this.client.execute(request).then(res => res.data);
+    const { data } = await this.client.execute(request);
+    return data;
   }
 
   /**
@@ -101,7 +102,7 @@ export default class Bucket {
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  setData(data, options = {}) {
+  async setData(data, options = {}) {
     if (!isObject(data)) {
       throw new Error("A bucket object is required.");
     }
@@ -123,7 +124,7 @@ export default class Bucket {
       { data: bucket, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -134,10 +135,10 @@ export default class Bucket {
    * @return {Promise<Array<Object>, Error>}
    */
   @capable(["history"])
-  listHistory(options = {}) {
+  async listHistory(options = {}) {
     const path = endpoint("history", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return await this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -147,10 +148,10 @@ export default class Bucket {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Array<Object>, Error>}
    */
-  listCollections(options = {}) {
+  async listCollections(options = {}) {
     const path = endpoint("collection", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return await this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -164,7 +165,7 @@ export default class Bucket {
    * @param  {Object}  [options.data]        The data object.
    * @return {Promise<Object, Error>}
    */
-  createCollection(id, options = {}) {
+  async createCollection(id, options = {}) {
     const reqOptions = this._bucketOptions(options);
     const { permissions, data = {} } = reqOptions;
     data.id = id;
@@ -174,7 +175,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -187,7 +188,7 @@ export default class Bucket {
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  deleteCollection(collection, options = {}) {
+  async deleteCollection(collection, options = {}) {
     const collectionObj = toDataBody(collection);
     if (!collectionObj.id) {
       throw new Error("A collection id is required.");
@@ -196,7 +197,7 @@ export default class Bucket {
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("collection", this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -206,10 +207,10 @@ export default class Bucket {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Array<Object>, Error>}
    */
-  listGroups(options = {}) {
+  async listGroups(options = {}) {
     const path = endpoint("group", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return await this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -220,10 +221,10 @@ export default class Bucket {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getGroup(id, options = {}) {
+  async getGroup(id, options = {}) {
     const reqOptions = { ...this._bucketOptions(options) };
     const request = { ...reqOptions, path: endpoint("group", this.name, id) };
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -238,7 +239,7 @@ export default class Bucket {
    * @param  {Object}            [options.headers]     The headers object option.
    * @return {Promise<Object, Error>}
    */
-  createGroup(id, members = [], options = {}) {
+  async createGroup(id, members = [], options = {}) {
     const reqOptions = this._bucketOptions(options);
     const data = {
       ...options.data,
@@ -252,7 +253,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -267,7 +268,7 @@ export default class Bucket {
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  updateGroup(group, options = {}) {
+  async updateGroup(group, options = {}) {
     if (!isObject(group)) {
       throw new Error("A group object is required.");
     }
@@ -286,7 +287,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -299,13 +300,13 @@ export default class Bucket {
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  deleteGroup(group, options = {}) {
+  async deleteGroup(group, options = {}) {
     const groupObj = toDataBody(group);
     const { id, last_modified } = groupObj;
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("group", this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -315,10 +316,11 @@ export default class Bucket {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getPermissions(options = {}) {
+  async getPermissions(options = {}) {
     const reqOptions = this._bucketOptions(options);
     const request = { ...reqOptions, path: endpoint("bucket", this.name) };
-    return this.client.execute(request).then(res => res.permissions);
+    const { permissions } = await this.client.execute(request);
+    return permissions;
   }
 
   /**
@@ -331,7 +333,7 @@ export default class Bucket {
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  setPermissions(permissions, options = {}) {
+  async setPermissions(permissions, options = {}) {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -344,7 +346,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -357,7 +359,7 @@ export default class Bucket {
    * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */
-  batch(fn, options = {}) {
-    return this.client.batch(fn, this._bucketOptions(options));
+  async batch(fn, options = {}) {
+    return await this.client.batch(fn, this._bucketOptions(options));
   }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -124,7 +124,7 @@ export default class Bucket {
       { data: bucket, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -138,7 +138,7 @@ export default class Bucket {
   async listHistory(options = {}) {
     const path = endpoint("history", this.name);
     const reqOptions = this._bucketOptions(options);
-    return await this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -151,7 +151,7 @@ export default class Bucket {
   async listCollections(options = {}) {
     const path = endpoint("collection", this.name);
     const reqOptions = this._bucketOptions(options);
-    return await this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -175,7 +175,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -197,7 +197,7 @@ export default class Bucket {
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("collection", this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -210,7 +210,7 @@ export default class Bucket {
   async listGroups(options = {}) {
     const path = endpoint("group", this.name);
     const reqOptions = this._bucketOptions(options);
-    return await this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, reqOptions);
   }
 
   /**
@@ -224,7 +224,7 @@ export default class Bucket {
   async getGroup(id, options = {}) {
     const reqOptions = { ...this._bucketOptions(options) };
     const request = { ...reqOptions, path: endpoint("group", this.name, id) };
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -253,7 +253,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -287,7 +287,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -306,7 +306,7 @@ export default class Bucket {
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("group", this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -346,7 +346,7 @@ export default class Bucket {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -360,6 +360,6 @@ export default class Bucket {
    * @return {Promise<Object, Error>}
    */
   async batch(fn, options = {}) {
-    return await this.client.batch(fn, this._bucketOptions(options));
+    return this.client.batch(fn, this._bucketOptions(options));
   }
 }

--- a/src/collection.js
+++ b/src/collection.js
@@ -126,7 +126,7 @@ export default class Collection {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -166,7 +166,7 @@ export default class Collection {
       { data, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -188,7 +188,7 @@ export default class Collection {
       { data: record, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -218,7 +218,7 @@ export default class Collection {
       reqOptions
     );
     await this.client.execute(addAttachmentRequest, { stringify: false });
-    return await this.getRecord(id);
+    return this.getRecord(id);
   }
 
   /**
@@ -235,7 +235,7 @@ export default class Collection {
     const reqOptions = this._collOptions(options);
     const path = endpoint("attachment", this.bucket.name, this.name, recordId);
     const request = requests.deleteRequest(path, reqOptions);
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -264,7 +264,7 @@ export default class Collection {
       { data: record, permissions },
       reqOptions
     );
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -286,7 +286,7 @@ export default class Collection {
     const reqOptions = this._collOptions({ last_modified, ...options });
     const path = endpoint("record", this.bucket.name, this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -301,7 +301,7 @@ export default class Collection {
     const path = endpoint("record", this.bucket.name, this.name, id);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, path };
-    return await this.client.execute(request);
+    return this.client.execute(request);
   }
 
   /**
@@ -341,9 +341,9 @@ export default class Collection {
     const path = endpoint("record", this.bucket.name, this.name);
     const reqOptions = this._collOptions(options);
     if (options.hasOwnProperty("at")) {
-      return await this._getSnapshot(options.at);
+      return this._getSnapshot(options.at);
     } else {
-      return await this.client.paginatedList(path, options, reqOptions);
+      return this.client.paginatedList(path, options, reqOptions);
     }
   }
 
@@ -402,7 +402,7 @@ export default class Collection {
    */
   async batch(fn, options = {}) {
     const reqOptions = this._collOptions(options);
-    return await this.client.batch(fn, {
+    return this.client.batch(fn, {
       ...reqOptions,
       bucket: this.bucket.name,
       collection: this.name,

--- a/src/collection.js
+++ b/src/collection.js
@@ -80,13 +80,12 @@ export default class Collection {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Number, Error>}
    */
-  getTotalRecords(options = {}) {
+  async getTotalRecords(options = {}) {
     const path = endpoint("record", this.bucket.name, this.name);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, path, method: "HEAD" };
-    return this.client
-      .execute(request, { raw: true })
-      .then(({ headers }) => parseInt(headers.get("Total-Records"), 10));
+    const { headers } = await this.client.execute(request, { raw: true });
+    return parseInt(headers.get("Total-Records"), 10);
   }
 
   /**
@@ -96,11 +95,12 @@ export default class Collection {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getData(options = {}) {
+  async getData(options = {}) {
     const reqOptions = this._collOptions(options);
     const path = endpoint("collection", this.bucket.name, this.name);
     const request = { ...reqOptions, path };
-    return this.client.execute(request).then(res => res.data);
+    const { data } = await this.client.execute(request);
+    return data;
   }
 
   /**
@@ -113,7 +113,7 @@ export default class Collection {
    * @param  {Number}   [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  setData(data, options = {}) {
+  async setData(data, options = {}) {
     if (!isObject(data)) {
       throw new Error("A collection object is required.");
     }
@@ -126,7 +126,7 @@ export default class Collection {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -136,11 +136,12 @@ export default class Collection {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getPermissions(options = {}) {
+  async getPermissions(options = {}) {
     const path = endpoint("collection", this.bucket.name, this.name);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, path };
-    return this.client.execute(request).then(res => res.permissions);
+    const { permissions } = await this.client.execute(request);
+    return permissions;
   }
 
   /**
@@ -153,7 +154,7 @@ export default class Collection {
    * @param  {Number}   [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  setPermissions(permissions, options = {}) {
+  async setPermissions(permissions, options = {}) {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -165,7 +166,7 @@ export default class Collection {
       { data, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -178,7 +179,7 @@ export default class Collection {
    * @param  {Object}  [options.permissions] The permissions option.
    * @return {Promise<Object, Error>}
    */
-  createRecord(record, options = {}) {
+  async createRecord(record, options = {}) {
     const reqOptions = this._collOptions(options);
     const { permissions } = reqOptions;
     const path = endpoint("record", this.bucket.name, this.name, record.id);
@@ -187,7 +188,7 @@ export default class Collection {
       { data: record, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -205,7 +206,7 @@ export default class Collection {
    * @return {Promise<Object, Error>}
    */
   @capable(["attachments"])
-  addAttachment(dataURI, record = {}, options = {}) {
+  async addAttachment(dataURI, record = {}, options = {}) {
     const reqOptions = this._collOptions(options);
     const { permissions } = reqOptions;
     const id = record.id || uuid.v4();
@@ -216,9 +217,8 @@ export default class Collection {
       { data: record, permissions },
       reqOptions
     );
-    return this.client
-      .execute(addAttachmentRequest, { stringify: false })
-      .then(() => this.getRecord(id));
+    await this.client.execute(addAttachmentRequest, { stringify: false });
+    return await this.getRecord(id);
   }
 
   /**
@@ -231,11 +231,11 @@ export default class Collection {
    * @param  {Number}  [options.last_modified] The last_modified option.
    */
   @capable(["attachments"])
-  removeAttachment(recordId, options = {}) {
+  async removeAttachment(recordId, options = {}) {
     const reqOptions = this._collOptions(options);
     const path = endpoint("attachment", this.bucket.name, this.name, recordId);
     const request = requests.deleteRequest(path, reqOptions);
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -249,7 +249,7 @@ export default class Collection {
    * @param  {Object}  [options.permissions]   The permissions option.
    * @return {Promise<Object, Error>}
    */
-  updateRecord(record, options = {}) {
+  async updateRecord(record, options = {}) {
     if (!isObject(record)) {
       throw new Error("A record object is required.");
     }
@@ -264,7 +264,7 @@ export default class Collection {
       { data: record, permissions },
       reqOptions
     );
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -277,7 +277,7 @@ export default class Collection {
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  deleteRecord(record, options = {}) {
+  async deleteRecord(record, options = {}) {
     const recordObj = toDataBody(record);
     if (!recordObj.id) {
       throw new Error("A record id is required.");
@@ -286,7 +286,7 @@ export default class Collection {
     const reqOptions = this._collOptions({ last_modified, ...options });
     const path = endpoint("record", this.bucket.name, this.name, id);
     const request = requests.deleteRequest(path, reqOptions);
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -297,11 +297,11 @@ export default class Collection {
    * @param  {Object} [options.headers] The headers object option.
    * @return {Promise<Object, Error>}
    */
-  getRecord(id, options = {}) {
+  async getRecord(id, options = {}) {
     const path = endpoint("record", this.bucket.name, this.name, id);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, path };
-    return this.client.execute(request);
+    return await this.client.execute(request);
   }
 
   /**
@@ -337,57 +337,57 @@ export default class Collection {
    * @param  {Number}   [options.since=null]            Only retrieve records modified since the provided timestamp.
    * @return {Promise<Object, Error>}
    */
-  listRecords(options = {}) {
+  async listRecords(options = {}) {
     const path = endpoint("record", this.bucket.name, this.name);
     const reqOptions = this._collOptions(options);
     if (options.hasOwnProperty("at")) {
-      return this._getSnapshot(options.at);
+      return await this._getSnapshot(options.at);
     } else {
-      return this.client.paginatedList(path, options, reqOptions);
+      return await this.client.paginatedList(path, options, reqOptions);
     }
   }
 
   /**
    * @private
    */
-  _getSnapshot(at) {
+  async _getSnapshot(at) {
     if (!Number.isInteger(at) || at <= 0) {
       throw new Error("Invalid argument, expected a positive integer.");
     }
     // TODO: we process history changes forward, while it would probably be more
     // efficient and accurate to process them backward.
-    return this.bucket
-      .listHistory({
-        pages: Infinity, // all pages up to target timestamp are required
-        sort: "-target.data.last_modified",
-        filters: {
-          resource_name: "record",
-          collection_id: this.name,
-          "max_target.data.last_modified": String(at),
-        },
-      })
-      .then(({ data: changes }) => {
-        const seenIds = new Set();
-        let snapshot = [];
-        for (const { action, target: { data: record } } of changes) {
-          if (action == "delete") {
-            seenIds.add(record.id); // ensure not reprocessing deleted entries
-            snapshot = snapshot.filter(r => r.id !== record.id);
-          } else if (!seenIds.has(record.id)) {
-            seenIds.add(record.id);
-            snapshot.push(record);
-          }
-        }
-        return {
-          last_modified: String(at),
-          data: snapshot.sort((a, b) => b.last_modified - a.last_modified),
-          next: () => {
-            throw new Error("Snapshots don't support pagination");
-          },
-          hasNextPage: false,
-          totalRecords: snapshot.length,
-        };
-      });
+    const { data: changes } = await this.bucket.listHistory({
+      pages: Infinity, // all pages up to target timestamp are required
+      sort: "-target.data.last_modified",
+      filters: {
+        resource_name: "record",
+        collection_id: this.name,
+        "max_target.data.last_modified": String(at),
+      },
+    });
+
+    const seenIds = new Set();
+    let snapshot = [];
+
+    for (const { action, target: { data: record } } of changes) {
+      if (action == "delete") {
+        seenIds.add(record.id); // ensure not reprocessing deleted entries
+        snapshot = snapshot.filter(r => r.id !== record.id);
+      } else if (!seenIds.has(record.id)) {
+        seenIds.add(record.id);
+        snapshot.push(record);
+      }
+    }
+
+    return {
+      last_modified: String(at),
+      data: snapshot.sort((a, b) => b.last_modified - a.last_modified),
+      next: () => {
+        throw new Error("Snapshots don't support pagination");
+      },
+      hasNextPage: false,
+      totalRecords: snapshot.length,
+    };
   }
 
   /**
@@ -400,9 +400,9 @@ export default class Collection {
    * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */
-  batch(fn, options = {}) {
+  async batch(fn, options = {}) {
     const reqOptions = this._collOptions(options);
-    return this.client.batch(fn, {
+    return await this.client.batch(fn, {
       ...reqOptions,
       bucket: this.bucket.name,
       collection: this.name,

--- a/src/http.js
+++ b/src/http.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import { delay } from "./utils";
 import ERROR_CODES from "./errors";
 
 /**
@@ -145,15 +146,9 @@ export default class HTTP {
   /**
    * @private
    */
-  retry(url, retryAfter, options) {
-    return new Promise((resolve, reject) => {
-      setTimeout(
-        () => {
-          resolve(this.request(url, { ...options, retry: options.retry - 1 }));
-        },
-        retryAfter
-      );
-    });
+  async retry(url, retryAfter, options) {
+    await delay(retryAfter);
+    return await this.request(url, { ...options, retry: options.retry - 1 });
   }
 
   /**

--- a/src/http.js
+++ b/src/http.js
@@ -79,23 +79,19 @@ export default class HTTP {
           this.timeout
         );
       }
+      function proceedWithHandler(fn) {
+        return arg => {
+          if (!hasTimedout) {
+            if (_timeoutId) {
+              clearTimeout(_timeoutId);
+            }
+            fn(arg);
+          }
+        };
+      }
       fetch(url, options)
-        .then(res => {
-          if (!hasTimedout) {
-            if (_timeoutId) {
-              clearTimeout(_timeoutId);
-            }
-            resolve(res);
-          }
-        })
-        .catch(err => {
-          if (!hasTimedout) {
-            if (_timeoutId) {
-              clearTimeout(_timeoutId);
-            }
-            reject(err);
-          }
-        });
+        .then(proceedWithHandler(resolve))
+        .catch(proceedWithHandler(reject));
     });
   }
 

--- a/src/http.js
+++ b/src/http.js
@@ -144,7 +144,7 @@ export default class HTTP {
    */
   async retry(url, retryAfter, options) {
     await delay(retryAfter);
-    return await this.request(url, { ...options, retry: options.retry - 1 });
+    return this.request(url, { ...options, retry: options.retry - 1 });
   }
 
   /**
@@ -181,9 +181,9 @@ export default class HTTP {
     const retryAfter = this._checkForRetryAfterHeader(status, headers);
     // If number of allowed of retries is not exhausted, retry the same request.
     if (retryAfter && options.retry > 0) {
-      return await this.retry(url, retryAfter, options);
+      return this.retry(url, retryAfter, options);
     } else {
-      return await this.processResponse(response);
+      return this.processResponse(response);
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export function partition(array, n) {
 }
 
 /**
- * Returns a Promise awlays resolving after the specified amount in milliseconds.
+ * Returns a Promise always resolving after the specified amount in milliseconds.
  *
  * @return Promise<void>
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,15 @@ export function partition(array, n) {
 }
 
 /**
+ * Returns a Promise awlays resolving after the specified amount in milliseconds.
+ *
+ * @return Promise<void>
+ */
+export function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
  * Maps a list to promises using the provided mapping function, executes them
  * sequentially then returns a Promise resolving with ordered results obtained.
  * Think of this as a sequential Promise.all.

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,20 +33,16 @@ export function partition(array, n) {
  * @param  {Function} fn   The mapping function.
  * @return {Promise}
  */
-export function pMap(list, fn) {
+export async function pMap(list, fn) {
   let results = [];
-  return list
-    .reduce(
-      (promise, entry) => {
-        return promise.then(() => {
-          return Promise.resolve(fn(entry)).then(
-            result => results = results.concat(result)
-          );
-        });
-      },
-      Promise.resolve()
-    )
-    .then(() => results);
+  await list.reduce(
+    async function(promise, entry) {
+      await promise;
+      results = results.concat(await fn(entry));
+    },
+    Promise.resolve()
+  );
+  return results;
 }
 
 /**

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -721,10 +721,12 @@ describe("KintoClient", () => {
       });
 
       it("should throw if the since option is invalid", () => {
-        expect(() => api.paginatedList(path, { since: 123 })).to.Throw(
-          Error,
-          /Invalid value for since \(123\), should be ETag value/
-        );
+        return api
+          .paginatedList(path, { since: 123 })
+          .should.be.rejectedWith(
+            Error,
+            /Invalid value for since \(123\), should be ETag value/
+          );
       });
 
       it("should resolve with the collection last_modified without quotes", () => {

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -507,17 +507,15 @@ describe("Bucket", () => {
     });
 
     it("should throw if record is not an object", () => {
-      expect(() => getBlogBucket().updateGroup(2)).to.Throw(
-        Error,
-        /group object is required/
-      );
+      return getBlogBucket()
+        .updateGroup()
+        .should.be.rejectedWith(Error, /group object is required/);
     });
 
     it("should throw if id is missing", () => {
-      expect(() => getBlogBucket().updateGroup({})).to.Throw(
-        Error,
-        /group id is required/
-      );
+      return getBlogBucket()
+        .updateGroup({})
+        .should.be.rejectedWith(Error, /group id is required/);
     });
 
     it("should accept a patch option", () => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import chai, { expect } from "chai";
+import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import sinon from "sinon";
 import KintoClient from "../src";
@@ -270,17 +270,15 @@ describe("Collection", () => {
     });
 
     it("should throw if record is not an object", () => {
-      expect(() => coll.updateRecord(2)).to.Throw(
-        Error,
-        /record object is required/
-      );
+      return coll
+        .updateRecord(2)
+        .should.be.rejectedWith(Error, /record object is required/);
     });
 
     it("should throw if id is missing", () => {
-      expect(() => coll.updateRecord({})).to.Throw(
-        Error,
-        /record id is required/
-      );
+      return coll
+        .updateRecord({})
+        .should.be.rejectedWith(Error, /record id is required/);
     });
 
     it("should create the expected request", () => {
@@ -350,10 +348,9 @@ describe("Collection", () => {
     });
 
     it("should throw if id is missing", () => {
-      expect(() => coll.deleteRecord({})).to.Throw(
-        Error,
-        /record id is required/
-      );
+      return coll
+        .deleteRecord({})
+        .should.be.rejectedWith(Error, /record id is required/);
     });
 
     it("should delete a record", () => {

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -129,9 +129,7 @@ describe("HTTP class", () => {
             setTimeout(resolve, 20000);
           })
         );
-        return http
-          .request("/")
-          .should.eventually.be.rejectedWith(Error, /timeout/);
+        return http.request("/").should.be.rejectedWith(Error, /timeout/);
       });
     });
 

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -161,7 +161,7 @@ describe("HTTP class", () => {
               },
             },
             text() {
-              return "invalid JSON";
+              return Promise.resolve("invalid JSON");
             },
           })
         );

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -12,7 +12,7 @@ export function fakeServerResponse(status, json, headers = {}) {
       },
     },
     text() {
-      return JSON.stringify(json);
+      return Promise.resolve(JSON.stringify(json));
     },
   });
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,6 +4,7 @@ import chai, { expect } from "chai";
 
 import {
   partition,
+  delay,
   pMap,
   omit,
   qsify,
@@ -31,6 +32,16 @@ describe("Utils", () => {
     it("should not chunk array with n<=0", () => {
       expect(partition([1, 2, 3], 0)).eql([1, 2, 3]);
       expect(partition([1, 2, 3], -1)).eql([1, 2, 3]);
+    });
+  });
+
+  /** @test {delay} */
+  describe("#delay", () => {
+    it("should delay resolution after the specified amount of time", () => {
+      const start = new Date().getTime();
+      return delay(10).then(() => {
+        expect(new Date().getTime() - start).within(10, 11);
+      });
     });
   });
 


### PR DESCRIPTION
Migrate our current async source code to use [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function).

Notes:
 
- The http.js module preliminary refactoring has been isolated in a [single commit](https://github.com/Kinto/kinto-http.js/pull/174/commits/23f376e8e367e82566dcdbd8a0dd1508ef373e97) to ease the review process.
- The diff is slightly larger mostly because of that large http.js module refactoring.