### PR TITLE
Improve test server crash reporting, allow using external test server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 - curl https://raw.githubusercontent.com/Kinto/kinto/master/requirements.txt > versions.txt
 - if [[ $SERVER && $SERVER != "master" ]]; then pip install kinto==$SERVER; fi
 - if [[ $SERVER && $SERVER == "master" ]]; then pip install https://github.com/Kinto/kinto/zipball/master; fi
-- pip install kinto-attachment
+- pip install https://github.com/Kinto/kinto-attachment/zipball/master
 - export KINTO_PSERVE_EXECUTABLE=pserve
 script:
 - npm $ACTION

--- a/README.md
+++ b/README.md
@@ -1581,3 +1581,11 @@ The `cs-check` command ensures all files conform to that style:
 ```
 $ npm run cs-check
 ```
+
+### Integration tests
+
+It's possible to run the integration test suite against an external Kinto server instance. To do so you need to define the `TEST_KINTO_SERVER` environment variable and set it to the server base URL:
+
+```
+$ TEST_KINTO_SERVER=https://my.kinto-server.tld/v1 npm test
+```

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -34,9 +34,11 @@ describe("Integration tests", function() {
   });
 
   after(() => {
-    if (server.logs.length > 0) {
+    const logLines = server.logs.toString().split("\n");
+    const serverDidCrash = logLines.some(l => l.startsWith("Traceback"));
+    if (serverDidCrash) {
       // Server errors have been encountered, raise to break the build
-      const trace = server.logs.map(l => l.toString()).join("\n");
+      const trace = logLines.join("\n");
       throw new Error(
         `Kinto server crashed while running the test suite.\n\n${trace}`
       );

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -14,7 +14,17 @@ chai.use(chaiAsPromised);
 chai.should();
 chai.config.includeStack = true;
 
-const TEST_KINTO_SERVER = "http://0.0.0.0:8888/v1";
+const skipLocalServer = !!process.env.TEST_KINTO_SERVER;
+const TEST_KINTO_SERVER = process.env.TEST_KINTO_SERVER ||
+  "http://0.0.0.0:8888/v1";
+
+function startServer(server, options) {
+  return !skipLocalServer && server.start(options);
+}
+
+function stopServer(server) {
+  return !skipLocalServer && server.stop();
+}
 
 describe("Integration tests", function() {
   let sandbox, server, api;
@@ -23,6 +33,9 @@ describe("Integration tests", function() {
   this.timeout(0);
 
   before(() => {
+    if (skipLocalServer) {
+      return;
+    }
     let kintoConfigPath = __dirname + "/kinto.ini";
     if (process.env.SERVER && process.env.SERVER !== "master") {
       kintoConfigPath = `${__dirname}/kinto-${process.env.SERVER}.ini`;
@@ -34,6 +47,9 @@ describe("Integration tests", function() {
   });
 
   after(() => {
+    if (skipLocalServer) {
+      return;
+    }
     const logLines = server.logs.toString().split("\n");
     const serverDidCrash = logLines.some(l => l.startsWith("Traceback"));
     if (serverDidCrash) {
@@ -65,10 +81,12 @@ describe("Integration tests", function() {
 
   describe("Default server configuration", () => {
     before(() => {
-      return server.start();
+      return startServer(server);
     });
 
-    after(() => server.stop());
+    after(() => {
+      return stopServer(server);
+    });
 
     beforeEach(() => server.flush());
 
@@ -504,10 +522,10 @@ describe("Integration tests", function() {
     const backoffSeconds = 10;
 
     before(() => {
-      return server.start({ KINTO_BACKOFF: backoffSeconds });
+      return startServer(server, { KINTO_BACKOFF: backoffSeconds });
     });
 
-    after(() => server.stop());
+    after(() => stopServer(server));
 
     beforeEach(() => server.flush());
 
@@ -527,14 +545,14 @@ describe("Integration tests", function() {
         const tomorrow = new Date(new Date().getTime() + 86400000)
           .toJSON()
           .slice(0, 10);
-        return server.start({
+        return startServer(server, {
           KINTO_EOS: tomorrow,
           KINTO_EOS_URL: "http://www.perdu.com",
           KINTO_EOS_MESSAGE: "Boom",
         });
       });
 
-      after(() => server.stop());
+      after(() => stopServer(server));
 
       beforeEach(() => sandbox.stub(console, "warn"));
 
@@ -554,14 +572,14 @@ describe("Integration tests", function() {
         const lastWeek = new Date(new Date().getTime() - 7 * 86400000)
           .toJSON()
           .slice(0, 10);
-        return server.start({
+        return startServer(server, {
           KINTO_EOS: lastWeek,
           KINTO_EOS_URL: "http://www.perdu.com",
           KINTO_EOS_MESSAGE: "Boom",
         });
       });
 
-      after(() => server.stop());
+      after(() => stopServer(server));
 
       beforeEach(() => sandbox.stub(console, "warn"));
 
@@ -575,10 +593,10 @@ describe("Integration tests", function() {
 
   describe("Limited pagination", () => {
     before(() => {
-      return server.start({ KINTO_PAGINATE_BY: 1 });
+      return startServer(server, { KINTO_PAGINATE_BY: 1 });
     });
 
-    after(() => server.stop());
+    after(() => stopServer(server));
 
     beforeEach(() => server.flush());
 
@@ -610,11 +628,9 @@ describe("Integration tests", function() {
   });
 
   describe("Chainable API", () => {
-    before(() => {
-      return server.start();
-    });
+    before(() => startServer(server));
 
-    after(() => server.stop());
+    after(() => stopServer(server));
 
     beforeEach(() => server.flush());
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -33,7 +33,16 @@ describe("Integration tests", function() {
     });
   });
 
-  after(() => server.killAll());
+  after(() => {
+    if (server.logs.length > 0) {
+      // Server errors have been encountered, raise to break the build
+      const trace = server.logs.map(l => l.toString()).join("\n");
+      throw new Error(
+        `Kinto server crashed while running the test suite.\n\n${trace}`
+      );
+    }
+    return server.killAll();
+  });
 
   function createClient(options = {}) {
     return new Api(TEST_KINTO_SERVER, options);


### PR DESCRIPTION
This patch improves Kinto test server crash reporting for better debuggability:

![](http://i.imgur.com/rwSo2Bc.png)