### PR TITLE
integration_test: Always initialize `server` variable

### DIFF
--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -33,9 +33,6 @@ describe("Integration tests", function() {
   this.timeout(0);
 
   before(() => {
-    if (skipLocalServer) {
-      return;
-    }
     let kintoConfigPath = __dirname + "/kinto.ini";
     if (process.env.SERVER && process.env.SERVER !== "master") {
       kintoConfigPath = `${__dirname}/kinto-${process.env.SERVER}.ini`;


### PR DESCRIPTION
Otherwise, we get errors that we cannot read `flush` of undefined.