### PR TITLE
integration_test: show how listCollections breaks

### DIFF
--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -176,7 +176,7 @@ describe("Bucket", () => {
         client.paginatedList,
         "/buckets/blog/collections",
         {},
-        { headers: { Foo: "Bar", Baz: "Qux" } }
+        { bucket: "blog", batch: false, headers: { Foo: "Bar", Baz: "Qux" } }
       );
     });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -896,6 +896,11 @@ describe("Integration tests", function() {
             .should.eventually.become(["c3", "c1", "c2", "c4"]);
         });
 
+        it("should work in a batch", () => {
+          return api.batch(batch => batch.bucket("custom").listCollections())
+            .should.eventually.become(["c4", "c3", "c2", "c1"]);
+        });
+
         describe("Filtering", () => {
           it("should filter collections", () => {
             return bucket


### PR DESCRIPTION
This appears to be the issue reported in
https://github.com/Kinto/kinto-admin/issues/421.

While we're here, add some parameters to the bucket_test to show what's going on.

I'm not sure if this issue exists in other places -- when I modified just this method in an attempt to work around the problem, I hit it in some other places. On the other hand, the tests appear to work successfully against kinto 7.0.0.