### PR TITLE
Refactor options so we can work with Kinto 7.0.0

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -391,16 +391,16 @@ export default class KintoClientBase {
       return raw ? { json: msg, headers: { get() {} } } : msg;
     }
     await this.fetchServerSettings();
-    // FIXME: Because any fetch() option is accepted here, `request`
-    // could have lots of parameters that wouldn't be accepted as part
-    // of a batch request. This makes it easier to shoot yourself in
-    // the foot. We should probably only pass through the four
-    // parameters accepted in a batch request: method, body, path, and
-    // headers.
     const result = await this.http.request(
       this.remote + request.path,
       {
-        ...request,
+        // Limit requests to only those parts that would be allowed in
+        // a batch request -- don't pass through other fancy fetch()
+        // options like integrity, redirect, mode because they will
+        // break on a batch request.  A batch request only allows
+        // headers, method, path (above), and body.
+        method: request.method,
+        headers: request.headers,
         body: stringify ? JSON.stringify(request.body) : request.body,
       },
       {

--- a/src/base.js
+++ b/src/base.js
@@ -197,6 +197,8 @@ export default class KintoClientBase {
 
   /**
    * As _getSafe, but for "retry".
+   *
+   * @private
    */
   _getRetry(options) {
     return { retry: this._retry, ...options }.retry;

--- a/src/base.js
+++ b/src/base.js
@@ -337,9 +337,6 @@ export default class KintoClientBase {
       events: this.events,
       batch: true,
       safe: this._getSafe(options),
-      // FIXME: this doesn't actually matter, probably, since it gets
-      // passed as "default headers" in the batch?
-      headers: this._getHeaders(options),
       retry: this._getRetry(options),
     });
     let bucketBatch, collBatch;

--- a/src/base.js
+++ b/src/base.js
@@ -513,12 +513,10 @@ export default class KintoClientBase {
 
     return handleResponse(
       await this.execute(
-        // FIXME: path should override options, and we should probably
-        // not respect options.method or options.body
         // N.B.: This doesn't use _getHeaders, because all calls to
         // `paginatedList` are assumed to come from calls that already
         // have headers merged at e.g. the bucket or collection level.
-        { path: path + "?" + querystring, ...options },
+        { headers: options.headers, path: path + "?" + querystring },
         // N.B. This doesn't use _getRetry, because all calls to
         // `paginatedList` are assumed to come from calls that already
         // used `_getRetry` at e.g. the bucket or collection level.

--- a/src/base.js
+++ b/src/base.js
@@ -1,14 +1,6 @@
 "use strict";
 
-import {
-  getOptionWithDefault,
-  partition,
-  pMap,
-  qsify,
-  support,
-  nobatch,
-  toDataBody,
-} from "./utils";
+import { partition, pMap, qsify, support, nobatch, toDataBody } from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -200,14 +192,14 @@ export default class KintoClientBase {
    * @returns {Boolean}
    */
   _getSafe(options) {
-    return getOptionWithDefault(options, "safe", this._safe);
+    return { safe: this._safe, ...options }.safe;
   }
 
   /**
    * As _getSafe, but for "retry".
    */
   _getRetry(options) {
-    return getOptionWithDefault(options, "retry", this._retry);
+    return { retry: this._retry, ...options }.retry;
   }
 
   /**

--- a/src/base.js
+++ b/src/base.js
@@ -533,7 +533,7 @@ export default class KintoClientBase {
    */
   async createBucket(id, options = {}) {
     const reqOptions = this._getRequestOptions(options);
-    const { data = {}, permissions } = reqOptions;
+    const { data = {}, permissions } = options;
     if (id != null) {
       data.id = id;
     }

--- a/src/base.js
+++ b/src/base.js
@@ -298,7 +298,7 @@ export default class KintoClientBase {
       {
         // FIXME: is this really necessary, since it's also present in
         // the "defaults"?
-        headers: headers,
+        headers,
         path: endpoint("batch"),
         method: "POST",
         body: {

--- a/src/base.js
+++ b/src/base.js
@@ -222,12 +222,8 @@ export default class KintoClientBase {
     const path = this.remote + endpoint("root");
     const { json } = await this.http.request(
       path,
-      {
-        headers: this._getHeaders(options),
-      },
-      {
-        retry: this._getRetry(options),
-      }
+      { headers: this._getHeaders(options) },
+      { retry: this._getRetry(options) }
     );
     this.serverInfo = json;
     return this.serverInfo;
@@ -312,9 +308,7 @@ export default class KintoClientBase {
           requests,
         },
       },
-      {
-        retry: this._getRetry(options),
-      }
+      { retry: this._getRetry(options) }
     );
     return responses;
   }
@@ -403,9 +397,7 @@ export default class KintoClientBase {
         headers: request.headers,
         body: stringify ? JSON.stringify(request.body) : request.body,
       },
-      {
-        retry: this._getRetry(options),
-      }
+      { retry: this._getRetry(options) }
     );
     return raw ? result : result.json;
   }

--- a/src/base.js
+++ b/src/base.js
@@ -398,8 +398,8 @@ export default class KintoClientBase {
    * JSON.
    * @return {Promise<Object, Error>}
    */
-  async execute(request, options = { raw: false, stringify: true }) {
-    const { raw, stringify } = options;
+  async execute(request, options = {}) {
+    const { raw = false, stringify = true } = options;
     // If we're within a batch, add the request to the stack to send at once.
     if (this._isBatch) {
       this._requests.push(request);

--- a/src/base.js
+++ b/src/base.js
@@ -209,6 +209,10 @@ export default class KintoClientBase {
    * usually performed a single time during the instance lifecycle.
    *
    * @param  {Object}  [options={}] The request options.
+   * @param  {Object}  [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async fetchServerInfo(options = {}) {
@@ -520,7 +524,10 @@ export default class KintoClientBase {
    * Lists all permissions.
    *
    * @param  {Object} [options={}]      The options object.
-   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number} [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object[], Error>}
    */
   @capable(["permissions_endpoint"])
@@ -539,7 +546,10 @@ export default class KintoClientBase {
    * Retrieves the list of buckets.
    *
    * @param  {Object} [options={}]      The options object.
-   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number} [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object[], Error>}
    */
   async listBuckets(options = {}) {
@@ -558,6 +568,8 @@ export default class KintoClientBase {
    * @param  {Boolean}      [options.data]    The bucket data option.
    * @param  {Boolean}      [options.safe]    The safe option.
    * @param  {Object}       [options.headers] The headers object option.
+   * @param  {Number}       [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async createBucket(id, options = {}) {
@@ -587,6 +599,8 @@ export default class KintoClientBase {
    * @param  {Object}        [options={}]            The options object.
    * @param  {Boolean}       [options.safe]          The safe option.
    * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */

--- a/src/base.js
+++ b/src/base.js
@@ -195,7 +195,6 @@ export default class KintoClientBase {
     return {
       ...this.defaultReqOptions,
       ...options,
-      batch: this._isBatch,
       // Note: headers should never be overriden but extended
       headers: {
         ...this.defaultReqOptions.headers,

--- a/src/base.js
+++ b/src/base.js
@@ -309,7 +309,7 @@ export default class KintoClientBase {
         method: "POST",
         body: {
           defaults: { headers },
-          requests: requests,
+          requests,
         },
       },
       {

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -41,6 +41,7 @@ export default class Bucket {
     /**
      * @ignore
      */
+    this._headers = options.headers || {};
     this._safe = !!options.safe;
   }
 
@@ -52,14 +53,22 @@ export default class Bucket {
    * @return {Object}              The merged options.
    */
   _bucketOptions(options = {}) {
-    const headers = {
-      ...(this.options && this.options.headers),
-      ...options.headers,
-    };
     return {
       ...this.options,
       ...options,
-      headers,
+    };
+  }
+
+  /**
+   * Get the value of "headers" for a given request, merging the
+   * per-request headers with our own "default" headers.
+   *
+   * @private
+   */
+  _getHeaders(options) {
+    return {
+      ...this._headers,
+      ...options.headers,
     };
   }
 
@@ -88,6 +97,7 @@ export default class Bucket {
     return new Collection(this.client, this, name, {
       ...this._bucketOptions(options),
       batch: this._isBatch,
+      headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
   }
@@ -101,7 +111,11 @@ export default class Bucket {
    */
   async getData(options = {}) {
     const reqOptions = { ...this._bucketOptions(options) };
-    const request = { ...reqOptions, path: endpoint("bucket", this.name) };
+    const request = {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+      path: endpoint("bucket", this.name),
+    };
     const { data } = await this.client.execute(request);
     return data;
   }
@@ -136,7 +150,11 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data: bucket, permissions },
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -152,7 +170,10 @@ export default class Bucket {
   async listHistory(options = {}) {
     const path = endpoint("history", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+    });
   }
 
   /**
@@ -165,7 +186,10 @@ export default class Bucket {
   async listCollections(options = {}) {
     const path = endpoint("collection", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+    });
   }
 
   /**
@@ -187,7 +211,11 @@ export default class Bucket {
     const request = requests.createRequest(
       path,
       { data, permissions },
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -212,6 +240,7 @@ export default class Bucket {
     const path = endpoint("collection", this.name, id);
     const request = requests.deleteRequest(path, {
       ...reqOptions,
+      headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
     return this.client.execute(request);
@@ -227,7 +256,10 @@ export default class Bucket {
   async listGroups(options = {}) {
     const path = endpoint("group", this.name);
     const reqOptions = this._bucketOptions(options);
-    return this.client.paginatedList(path, options, reqOptions);
+    return this.client.paginatedList(path, options, {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+    });
   }
 
   /**
@@ -240,7 +272,11 @@ export default class Bucket {
    */
   async getGroup(id, options = {}) {
     const reqOptions = { ...this._bucketOptions(options) };
-    const request = { ...reqOptions, path: endpoint("group", this.name, id) };
+    const request = {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+      path: endpoint("group", this.name, id),
+    };
     return this.client.execute(request);
   }
 
@@ -268,7 +304,11 @@ export default class Bucket {
     const request = requests.createRequest(
       path,
       { data, permissions },
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -302,7 +342,11 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data, permissions },
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -324,6 +368,7 @@ export default class Bucket {
     const path = endpoint("group", this.name, id);
     const request = requests.deleteRequest(path, {
       ...reqOptions,
+      headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
     return this.client.execute(request);
@@ -338,7 +383,11 @@ export default class Bucket {
    */
   async getPermissions(options = {}) {
     const reqOptions = this._bucketOptions(options);
-    const request = { ...reqOptions, path: endpoint("bucket", this.name) };
+    const request = {
+      ...reqOptions,
+      headers: this._getHeaders(options),
+      path: endpoint("bucket", this.name),
+    };
     const { permissions } = await this.client.execute(request);
     return permissions;
   }
@@ -364,7 +413,11 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data, permissions },
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -390,7 +443,11 @@ export default class Bucket {
       path,
       permissions,
       "add",
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -416,7 +473,11 @@ export default class Bucket {
       path,
       permissions,
       "remove",
-      { ...reqOptions, safe: this._getSafe(options) }
+      {
+        ...reqOptions,
+        headers: this._getHeaders(options),
+        safe: this._getSafe(options),
+      }
     );
     return this.client.execute(request);
   }
@@ -436,6 +497,7 @@ export default class Bucket {
     return this.client.batch(fn, {
       ...this._bucketOptions(options),
       bucket: this.name,
+      headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
   }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -335,7 +335,7 @@ export default class Bucket {
       throw new Error("A permissions object is required.");
     }
     const path = endpoint("bucket", this.name);
-    const reqOptions = { ...this._bucketOptions(options) };
+    const reqOptions = this._bucketOptions(options);
     const { last_modified } = options;
     const data = { last_modified };
     const request = requests.updateRequest(

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -16,6 +16,7 @@ export default class Bucket {
    * @param  {Object}      [options={}]      The headers object option.
    * @param  {Object}      [options.headers] The headers object option.
    * @param  {Boolean}     [options.safe]    The safe option.
+   * @param  {Number}      [options.retry]   The retry option.
    */
   constructor(client, name, options = {}) {
     /**
@@ -404,6 +405,7 @@ export default class Bucket {
    * @param  {Object}   [options={}]         The options object.
    * @param  {Object}   [options.headers]    The headers object option.
    * @param  {Boolean}  [options.safe]       The safe option.
+   * @param  {Number}   [options.retry]      The retry option.
    * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -164,7 +164,7 @@ export default class Bucket {
    */
   async createCollection(id, options = {}) {
     const reqOptions = this._bucketOptions(options);
-    const { permissions, data = {} } = reqOptions;
+    const { permissions, data = {} } = options;
     data.id = id;
     const path = endpoint("collection", this.name, id);
     const request = requests.createRequest(

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -1,4 +1,4 @@
-import { toDataBody, isObject, capable } from "./utils";
+import { getOptionWithDefault, toDataBody, isObject, capable } from "./utils";
 import Collection from "./collection";
 import * as requests from "./requests";
 import endpoint from "./endpoint";
@@ -38,6 +38,10 @@ export default class Bucket {
      * @ignore
      */
     this._isBatch = !!options.batch;
+    /**
+     * @ignore
+     */
+    this._safe = !!options.safe;
   }
 
   /**
@@ -60,6 +64,18 @@ export default class Bucket {
   }
 
   /**
+   * Get the value of "safe" for a given request, using the
+   * per-request option if present or falling back to our default
+   * otherwise.
+   *
+   * @param {Object} options The options for a request.
+   * @returns {Boolean}
+   */
+  _getSafe(options) {
+    return getOptionWithDefault(options, "safe", this._safe);
+  }
+
+  /**
    * Selects a collection.
    *
    * @param  {String}  name              The collection name.
@@ -72,6 +88,7 @@ export default class Bucket {
     return new Collection(this.client, this, name, {
       ...this._bucketOptions(options),
       batch: this._isBatch,
+      safe: this._getSafe(options),
     });
   }
 
@@ -119,7 +136,7 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data: bucket, permissions },
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -170,7 +187,7 @@ export default class Bucket {
     const request = requests.createRequest(
       path,
       { data, permissions },
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -193,7 +210,10 @@ export default class Bucket {
     const { id, last_modified } = collectionObj;
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("collection", this.name, id);
-    const request = requests.deleteRequest(path, reqOptions);
+    const request = requests.deleteRequest(path, {
+      ...reqOptions,
+      safe: this._getSafe(options),
+    });
     return this.client.execute(request);
   }
 
@@ -248,7 +268,7 @@ export default class Bucket {
     const request = requests.createRequest(
       path,
       { data, permissions },
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -282,7 +302,7 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data, permissions },
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -302,7 +322,10 @@ export default class Bucket {
     const { id, last_modified } = groupObj;
     const reqOptions = this._bucketOptions({ last_modified, ...options });
     const path = endpoint("group", this.name, id);
-    const request = requests.deleteRequest(path, reqOptions);
+    const request = requests.deleteRequest(path, {
+      ...reqOptions,
+      safe: this._getSafe(options),
+    });
     return this.client.execute(request);
   }
 
@@ -341,7 +364,7 @@ export default class Bucket {
     const request = requests.updateRequest(
       path,
       { data, permissions },
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -367,7 +390,7 @@ export default class Bucket {
       path,
       permissions,
       "add",
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -393,7 +416,7 @@ export default class Bucket {
       path,
       permissions,
       "remove",
-      reqOptions
+      { ...reqOptions, safe: this._getSafe(options) }
     );
     return this.client.execute(request);
   }
@@ -413,6 +436,7 @@ export default class Bucket {
     return this.client.batch(fn, {
       ...this._bucketOptions(options),
       bucket: this.name,
+      safe: this._getSafe(options),
     });
   }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -55,7 +55,6 @@ export default class Bucket {
       ...this.options,
       ...options,
       headers,
-      batch: this._isBatch,
     };
   }
 
@@ -69,12 +68,10 @@ export default class Bucket {
    * @return {Collection}
    */
   collection(name, options = {}) {
-    return new Collection(
-      this.client,
-      this,
-      name,
-      this._bucketOptions(options)
-    );
+    return new Collection(this.client, this, name, {
+      ...this._bucketOptions(options),
+      batch: this._isBatch,
+    });
   }
 
   /**

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -504,15 +504,12 @@ export default class Bucket {
    * @return {Promise<Object, Error>}
    */
   async batch(fn, options = {}) {
-    let batchOptions = {
+    return this.client.batch(fn, {
       bucket: this.name,
       headers: this._getHeaders(options),
       retry: this._getRetry(options),
       safe: this._getSafe(options),
-    };
-    if (options.aggregate) {
-      batchOptions = { ...batchOptions, aggregate: options.aggregate };
-    }
-    return this.client.batch(fn, batchOptions);
+      aggregate: !!options.aggregate,
+    });
   }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -42,6 +42,7 @@ export default class Bucket {
      * @ignore
      */
     this._headers = options.headers || {};
+    this._retry = options.retry || 0;
     this._safe = !!options.safe;
   }
 
@@ -85,6 +86,13 @@ export default class Bucket {
   }
 
   /**
+   * As _getSafe, but for "retry".
+   */
+  _getRetry(options) {
+    return getOptionWithDefault(options, "retry", this._retry);
+  }
+
+  /**
    * Selects a collection.
    *
    * @param  {String}  name              The collection name.
@@ -98,6 +106,7 @@ export default class Bucket {
       ...this._bucketOptions(options),
       batch: this._isBatch,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
       safe: this._getSafe(options),
     });
   }
@@ -116,7 +125,9 @@ export default class Bucket {
       headers: this._getHeaders(options),
       path: endpoint("bucket", this.name),
     };
-    const { data } = await this.client.execute(request);
+    const { data } = await this.client.execute(request, {
+      retry: this._getRetry(options),
+    });
     return data;
   }
 
@@ -156,7 +167,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -173,6 +184,7 @@ export default class Bucket {
     return this.client.paginatedList(path, options, {
       ...reqOptions,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
     });
   }
 
@@ -189,6 +201,7 @@ export default class Bucket {
     return this.client.paginatedList(path, options, {
       ...reqOptions,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
     });
   }
 
@@ -217,7 +230,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -243,7 +256,7 @@ export default class Bucket {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -259,6 +272,7 @@ export default class Bucket {
     return this.client.paginatedList(path, options, {
       ...reqOptions,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
     });
   }
 
@@ -277,7 +291,7 @@ export default class Bucket {
       headers: this._getHeaders(options),
       path: endpoint("group", this.name, id),
     };
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -310,7 +324,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -348,7 +362,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -371,7 +385,7 @@ export default class Bucket {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -388,7 +402,9 @@ export default class Bucket {
       headers: this._getHeaders(options),
       path: endpoint("bucket", this.name),
     };
-    const { permissions } = await this.client.execute(request);
+    const { permissions } = await this.client.execute(request, {
+      retry: this._getRetry(options),
+    });
     return permissions;
   }
 
@@ -419,7 +435,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -449,7 +465,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -479,7 +495,7 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -498,6 +514,7 @@ export default class Bucket {
       ...this._bucketOptions(options),
       bucket: this.name,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
       safe: this._getSafe(options),
     });
   }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -98,6 +98,8 @@ export default class Bucket {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getData(options = {}) {
@@ -115,8 +117,10 @@ export default class Bucket {
    * Set bucket data.
    * @param  {Object}  data                    The bucket data object.
    * @param  {Object}  [options={}]            The options object.
-   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Object}  [options.headers={}]    The headers object option.
    * @param  {Boolean} [options.safe]          The safe option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean} [options.patch]         The patch option.
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
@@ -156,6 +160,8 @@ export default class Bucket {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Array<Object>, Error>}
    */
   @capable(["history"])
@@ -172,6 +178,8 @@ export default class Bucket {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Array<Object>, Error>}
    */
   async listCollections(options = {}) {
@@ -189,6 +197,8 @@ export default class Bucket {
    * @param  {Object}  [options={}]          The options object.
    * @param  {Boolean} [options.safe]        The safe option.
    * @param  {Object}  [options.headers]     The headers object option.
+   * @param  {Number}  [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.permissions] The permissions object.
    * @param  {Object}  [options.data]        The data object.
    * @return {Promise<Object, Error>}
@@ -214,6 +224,8 @@ export default class Bucket {
    * @param  {Object|String} collection              The collection to delete.
    * @param  {Object}        [options={}]            The options object.
    * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean}       [options.safe]          The safe option.
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
@@ -239,6 +251,8 @@ export default class Bucket {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Array<Object>, Error>}
    */
   async listGroups(options = {}) {
@@ -255,6 +269,8 @@ export default class Bucket {
    * @param  {String} id                The group id.
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getGroup(id, options = {}) {
@@ -275,6 +291,8 @@ export default class Bucket {
    * @param  {Object}            [options.permissions] The permissions object.
    * @param  {Boolean}           [options.safe]        The safe option.
    * @param  {Object}            [options.headers]     The headers object option.
+   * @param  {Number}            [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async createGroup(id, members = [], options = {}) {
@@ -305,6 +323,8 @@ export default class Bucket {
    * @param  {Object}  [options.permissions]   The permissions object.
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -341,6 +361,8 @@ export default class Bucket {
    * @param  {Object|String} group                   The group to delete.
    * @param  {Object}        [options={}]            The options object.
    * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean}       [options.safe]          The safe option.
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
@@ -363,6 +385,8 @@ export default class Bucket {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getPermissions(options = {}) {
@@ -382,7 +406,9 @@ export default class Bucket {
    * @param  {Object}  permissions             The permissions object.
    * @param  {Object}  [options={}]            The options object
    * @param  {Boolean} [options.safe]          The safe option.
-   * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Object}  [options.headers={}]    The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -411,6 +437,8 @@ export default class Bucket {
    * @param  {Object}  [options={}]            The options object
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -440,6 +468,8 @@ export default class Bucket {
    * @param  {Object}  [options={}]            The options object
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -469,7 +499,7 @@ export default class Bucket {
    * @param  {Object}   [options={}]         The options object.
    * @param  {Object}   [options.headers]    The headers object option.
    * @param  {Boolean}  [options.safe]       The safe option.
-   * @param  {Number}   [options.retry]      The retry option.
+   * @param  {Number}   [options.retry=0]    The retry option.
    * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -55,7 +55,6 @@ export default class Bucket {
       ...this.options,
       ...options,
       headers,
-      bucket: this.name,
       batch: this._isBatch,
     };
   }
@@ -412,6 +411,9 @@ export default class Bucket {
    * @return {Promise<Object, Error>}
    */
   async batch(fn, options = {}) {
-    return this.client.batch(fn, this._bucketOptions(options));
+    return this.client.batch(fn, {
+      ...this._bucketOptions(options),
+      bucket: this.name,
+    });
   }
 }

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -58,6 +58,7 @@ export default class Bucket {
    * per-request option if present or falling back to our default
    * otherwise.
    *
+   * @private
    * @param {Object} options The options for a request.
    * @returns {Boolean}
    */
@@ -67,6 +68,8 @@ export default class Bucket {
 
   /**
    * As _getSafe, but for "retry".
+   *
+   * @private
    */
   _getRetry(options) {
     return { retry: this._retry, ...options }.retry;

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -1,4 +1,4 @@
-import { getOptionWithDefault, toDataBody, isObject, capable } from "./utils";
+import { toDataBody, isObject, capable } from "./utils";
 import Collection from "./collection";
 import * as requests from "./requests";
 import endpoint from "./endpoint";
@@ -62,14 +62,14 @@ export default class Bucket {
    * @returns {Boolean}
    */
   _getSafe(options) {
-    return getOptionWithDefault(options, "safe", this._safe);
+    return { safe: this._safe, ...options }.safe;
   }
 
   /**
    * As _getSafe, but for "retry".
    */
   _getRetry(options) {
-    return getOptionWithDefault(options, "retry", this._retry);
+    return { retry: this._retry, ...options }.retry;
   }
 
   /**

--- a/src/collection.js
+++ b/src/collection.js
@@ -121,7 +121,7 @@ export default class Collection {
       throw new Error("A collection object is required.");
     }
     const reqOptions = this._collOptions(options);
-    const { permissions } = reqOptions;
+    const { permissions } = options;
 
     const path = endpoint("collection", this.bucket.name, this.name);
     const request = requests.updateRequest(
@@ -236,7 +236,7 @@ export default class Collection {
    */
   async createRecord(record, options = {}) {
     const reqOptions = this._collOptions(options);
-    const { permissions } = reqOptions;
+    const { permissions } = options;
     const path = endpoint("record", this.bucket.name, this.name, record.id);
     const request = requests.createRequest(
       path,
@@ -263,7 +263,7 @@ export default class Collection {
   @capable(["attachments"])
   async addAttachment(dataURI, record = {}, options = {}) {
     const reqOptions = this._collOptions(options);
-    const { permissions } = reqOptions;
+    const { permissions } = options;
     const id = record.id || uuid.v4();
     const path = endpoint("attachment", this.bucket.name, this.name, id);
     const addAttachmentRequest = requests.addAttachmentRequest(
@@ -312,7 +312,7 @@ export default class Collection {
       throw new Error("A record id is required.");
     }
     const reqOptions = this._collOptions(options);
-    const { permissions } = reqOptions;
+    const { permissions } = options;
     const path = endpoint("record", this.bucket.name, this.name, record.id);
     const request = requests.updateRequest(
       path,

--- a/src/collection.js
+++ b/src/collection.js
@@ -18,6 +18,7 @@ export default class Collection {
    * @param  {Object}       [options={}]      The options object.
    * @param  {Object}       [options.headers] The headers object option.
    * @param  {Boolean}      [options.safe]    The safe option.
+   * @param  {Number}       [options.retry]   The retry option.
    * @param  {Boolean}      [options.batch]   (Private) Whether this
    *     Collection is operating as part of a batch.
    */
@@ -483,6 +484,7 @@ export default class Collection {
    * @param  {Object}   [options={}]         The options object.
    * @param  {Object}   [options.headers]    The headers object option.
    * @param  {Boolean}  [options.safe]       The safe option.
+   * @param  {Number}   [options.retry]      The retry option.
    * @param  {Boolean}  [options.aggregate]  Produces a grouped result object.
    * @return {Promise<Object, Error>}
    */

--- a/src/collection.js
+++ b/src/collection.js
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 
-import { capable, getOptionWithDefault, toDataBody, isObject } from "./utils";
+import { capable, toDataBody, isObject } from "./utils";
 import * as requests from "./requests";
 import endpoint from "./endpoint";
 
@@ -77,14 +77,14 @@ export default class Collection {
    * @returns {Boolean}
    */
   _getSafe(options) {
-    return getOptionWithDefault(options, "safe", this._safe);
+    return { safe: this._safe, ...options }.safe;
   }
 
   /**
    * As _getSafe, but for "retry".
    */
   _getRetry(options) {
-    return getOptionWithDefault(options, "retry", this._retry);
+    return { retry: this._retry, ...options }.retry;
   }
 
   /**

--- a/src/collection.js
+++ b/src/collection.js
@@ -18,6 +18,8 @@ export default class Collection {
    * @param  {Object}       [options={}]      The options object.
    * @param  {Object}       [options.headers] The headers object option.
    * @param  {Boolean}      [options.safe]    The safe option.
+   * @param  {Boolean}      [options.batch]   (Private) Whether this
+   *     Collection is operating as part of a batch.
    */
   constructor(client, bucket, name, options = {}) {
     /**

--- a/src/collection.js
+++ b/src/collection.js
@@ -95,6 +95,8 @@ export default class Collection {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Number, Error>}
    */
   async getTotalRecords(options = {}) {
@@ -116,6 +118,8 @@ export default class Collection {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getData(options = {}) {
@@ -132,6 +136,8 @@ export default class Collection {
    * @param  {Object}   data                    The collection data object.
    * @param  {Object}   [options={}]            The options object.
    * @param  {Object}   [options.headers]       The headers object option.
+   * @param  {Number}   [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean}  [options.safe]          The safe option.
    * @param  {Boolean}  [options.patch]         The patch option.
    * @param  {Number}   [options.last_modified] The last_modified option.
@@ -162,6 +168,8 @@ export default class Collection {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getPermissions(options = {}) {
@@ -179,6 +187,8 @@ export default class Collection {
    * @param  {Object}   permissions             The permissions object.
    * @param  {Object}   [options={}]            The options object
    * @param  {Object}   [options.headers]       The headers object option.
+   * @param  {Number}   [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean}  [options.safe]          The safe option.
    * @param  {Number}   [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
@@ -207,6 +217,8 @@ export default class Collection {
    * @param  {Object}  [options={}]            The options object
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -236,6 +248,8 @@ export default class Collection {
    * @param  {Object}  [options={}]            The options object
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
@@ -264,6 +278,8 @@ export default class Collection {
    * @param  {Object}  record                The record to create.
    * @param  {Object}  [options={}]          The options object.
    * @param  {Object}  [options.headers]     The headers object option.
+   * @param  {Number}  [options.retry=0]     Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean} [options.safe]        The safe option.
    * @param  {Object}  [options.permissions] The permissions option.
    * @return {Promise<Object, Error>}
@@ -289,6 +305,8 @@ export default class Collection {
    * @param  {Object}  [record={}]             The record data.
    * @param  {Object}  [options={}]            The options object.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @param  {Object}  [options.permissions]   The permissions option.
@@ -327,6 +345,8 @@ export default class Collection {
    * @param  {Object}  recordId                The record id.
    * @param  {Object}  [options={}]            The options object.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Number}  [options.last_modified] The last_modified option.
    */
@@ -348,6 +368,8 @@ export default class Collection {
    * @param  {Object}  record                  The record to update.
    * @param  {Object}  [options={}]            The options object.
    * @param  {Object}  [options.headers]       The headers object option.
+   * @param  {Number}  [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean} [options.safe]          The safe option.
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @param  {Object}  [options.permissions]   The permissions option.
@@ -387,6 +409,8 @@ export default class Collection {
    * @param  {Object|String} record                  The record to delete.
    * @param  {Object}        [options={}]            The options object.
    * @param  {Object}        [options.headers]       The headers object option.
+   * @param  {Number}        [options.retry=0]       Number of retries to make
+   *     when faced with transient errors.
    * @param  {Boolean}       [options.safe]          The safe option.
    * @param  {Number}        [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
@@ -413,6 +437,8 @@ export default class Collection {
    * @param  {String} id                The record id to retrieve.
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getRecord(id, options = {}) {
@@ -446,6 +472,8 @@ export default class Collection {
    *
    * @param  {Object}   [options={}]                    The options object.
    * @param  {Object}   [options.headers]               The headers object option.
+   * @param  {Number}   [options.retry=0]               Number of retries to make
+   *     when faced with transient errors.
    * @param  {Object}   [options.filters=[]]            The filters object.
    * @param  {String}   [options.sort="-last_modified"] The sort field.
    * @param  {String}   [options.at]                    The timestamp to get a snapshot at.

--- a/src/collection.js
+++ b/src/collection.js
@@ -55,6 +55,7 @@ export default class Collection {
     /**
      * @ignore
      */
+    this._retry = options.retry || 0;
     this._safe = !!options.safe;
     // FIXME: This is kind of ugly; shouldn't the bucket be responsible
     // for doing the merge?
@@ -105,6 +106,13 @@ export default class Collection {
   }
 
   /**
+   * As _getSafe, but for "retry".
+   */
+  _getRetry(options) {
+    return getOptionWithDefault(options, "retry", this._retry);
+  }
+
+  /**
    * Retrieves the total number of records in this collection.
    *
    * @param  {Object} [options={}]      The options object.
@@ -120,7 +128,10 @@ export default class Collection {
       path,
       method: "HEAD",
     };
-    const { headers } = await this.client.execute(request, { raw: true });
+    const { headers } = await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    });
     return parseInt(headers.get("Total-Records"), 10);
   }
 
@@ -135,7 +146,9 @@ export default class Collection {
     const reqOptions = this._collOptions(options);
     const path = endpoint("collection", this.bucket.name, this.name);
     const request = { ...reqOptions, headers: this._getHeaders(options), path };
-    const { data } = await this.client.execute(request);
+    const { data } = await this.client.execute(request, {
+      retry: this._getRetry(options),
+    });
     return data;
   }
 
@@ -166,7 +179,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -180,7 +193,9 @@ export default class Collection {
     const path = endpoint("collection", this.bucket.name, this.name);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, headers: this._getHeaders(options), path };
-    const { permissions } = await this.client.execute(request);
+    const { permissions } = await this.client.execute(request, {
+      retry: this._getRetry(options),
+    });
     return permissions;
   }
 
@@ -210,7 +225,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -240,7 +255,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -270,7 +285,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -296,7 +311,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -329,7 +344,10 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    await this.client.execute(addAttachmentRequest, { stringify: false });
+    await this.client.execute(addAttachmentRequest, {
+      stringify: false,
+      retry: this._getRetry(options),
+    });
     return this.getRecord(id);
   }
 
@@ -351,7 +369,7 @@ export default class Collection {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -384,7 +402,7 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -410,7 +428,7 @@ export default class Collection {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -425,7 +443,7 @@ export default class Collection {
     const path = endpoint("record", this.bucket.name, this.name, id);
     const reqOptions = this._collOptions(options);
     const request = { ...reqOptions, headers: this._getHeaders(options), path };
-    return this.client.execute(request);
+    return this.client.execute(request, { retry: this._getRetry(options) });
   }
 
   /**
@@ -470,6 +488,7 @@ export default class Collection {
       return this.client.paginatedList(path, options, {
         ...reqOptions,
         headers: this._getHeaders(options),
+        retry: this._getRetry(options),
       });
     }
   }
@@ -567,6 +586,7 @@ export default class Collection {
       bucket: this.bucket.name,
       collection: this.name,
       headers: this._getHeaders(options),
+      retry: this._getRetry(options),
       safe: this._getSafe(options),
     });
   }

--- a/src/collection.js
+++ b/src/collection.js
@@ -73,6 +73,7 @@ export default class Collection {
    * per-request option if present or falling back to our default
    * otherwise.
    *
+   * @private
    * @param {Object} options The options for a request.
    * @returns {Boolean}
    */
@@ -82,6 +83,8 @@ export default class Collection {
 
   /**
    * As _getSafe, but for "retry".
+   *
+   * @private
    */
   _getRetry(options) {
     return { retry: this._retry, ...options }.retry;

--- a/src/http.js
+++ b/src/http.js
@@ -158,7 +158,7 @@ export default class HTTP {
    * @param  {String} url               The URL.
    * @param  {Object} [options={}]      The fetch() options object.
    * @param  {Object} [options.headers] The request headers object (default: {})
-   * @param  {Object} [options.retry]   Number of retries (default: 0)
+   * @param  {Number} [options.retry]   Number of retries (default: 0)
    * @return {Promise}
    */
   async request(url, options = { headers: {}, retry: 0 }) {

--- a/src/http.js
+++ b/src/http.js
@@ -142,9 +142,9 @@ export default class HTTP {
   /**
    * @private
    */
-  async retry(url, retryAfter, options) {
+  async retry(url, retryAfter, request, options) {
     await delay(retryAfter);
-    return this.request(url, { ...options, retry: options.retry - 1 });
+    return this.request(url, request, { ...options, retry: options.retry - 1 });
   }
 
   /**
@@ -156,22 +156,25 @@ export default class HTTP {
    * - `{Headers} headers` The response headers object; see the ES6 fetch() spec.
    *
    * @param  {String} url               The URL.
-   * @param  {Object} [options={}]      The fetch() options object.
-   * @param  {Object} [options.headers] The request headers object (default: {})
+   * @param  {Object} [request={}]      The request object, passed to
+   *     fetch() as its options object.
+   * @param  {Object} [request.headers] The request headers object (default: {})
+   * @param  {Object} [options={}]      Options for making the
+   *     request
    * @param  {Number} [options.retry]   Number of retries (default: 0)
    * @return {Promise}
    */
-  async request(url, options = { headers: {}, retry: 0 }) {
+  async request(url, request = { headers: {} }, options = { retry: 0 }) {
     // Ensure default request headers are always set
-    options.headers = { ...HTTP.DEFAULT_REQUEST_HEADERS, ...options.headers };
+    request.headers = { ...HTTP.DEFAULT_REQUEST_HEADERS, ...request.headers };
     // If a multipart body is provided, remove any custom Content-Type header as
     // the fetch() implementation will add the correct one for us.
-    if (options.body && typeof options.body.append === "function") {
-      delete options.headers["Content-Type"];
+    if (request.body && typeof request.body.append === "function") {
+      delete request.headers["Content-Type"];
     }
-    options.mode = this.requestMode;
+    request.mode = this.requestMode;
 
-    const response = await this.timedFetch(url, options);
+    const response = await this.timedFetch(url, request);
     const { status, headers } = response;
 
     this._checkForDeprecationHeader(headers);
@@ -181,7 +184,7 @@ export default class HTTP {
     const retryAfter = this._checkForRetryAfterHeader(status, headers);
     // If number of allowed of retries is not exhausted, retry the same request.
     if (retryAfter && options.retry > 0) {
-      return this.retry(url, retryAfter, options);
+      return this.retry(url, retryAfter, request, options);
     } else {
       return this.processResponse(response);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,6 +75,27 @@ export function omit(obj, ...keys) {
 }
 
 /**
+ * Get an option for a given request with a fallback.
+ *
+ * This is the JS equivalent of dict.get(key, fallback). We use it to
+ * let users specify per-method-call options while falling back to a
+ * per-object option if it's absent.
+ *
+ * @private
+ * @param {Object} options  The options passed to an arbitrary
+ *     method.
+ * @param {String} key      The option to look up.
+ * @param {Object} fallback The value to use if the key isn't present.
+ * @returns [Object]
+ */
+export function getOptionWithDefault(options, key, fallback) {
+  if (options.hasOwnProperty(key)) {
+    return options[key];
+  }
+  return fallback;
+}
+
+/**
  * Always returns a resource data object from the provided argument.
  *
  * @private

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,27 +75,6 @@ export function omit(obj, ...keys) {
 }
 
 /**
- * Get an option for a given request with a fallback.
- *
- * This is the JS equivalent of dict.get(key, fallback). We use it to
- * let users specify per-method-call options while falling back to a
- * per-object option if it's absent.
- *
- * @private
- * @param {Object} options  The options passed to an arbitrary
- *     method.
- * @param {String} key      The option to look up.
- * @param {Object} fallback The value to use if the key isn't present.
- * @returns [Object]
- */
-export function getOptionWithDefault(options, key, fallback) {
-  if (options.hasOwnProperty(key)) {
-    return options[key];
-  }
-  return fallback;
-}
-
-/**
  * Always returns a resource data object from the provided argument.
  *
  * @private

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -117,7 +117,7 @@ describe("KintoClient", () => {
 
     it("should accept a safe option", () => {
       const api = new KintoClient(sampleRemote, { safe: true });
-      expect(api.defaultReqOptions.safe).eql(true);
+      expect(api._safe).eql(true);
     });
   });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -110,11 +110,6 @@ describe("KintoClient", () => {
       expect(new KintoClient(sampleRemote, { events }).events).eql(events);
     });
 
-    it("should accept a bucket option", () => {
-      const api = new KintoClient(sampleRemote, { bucket: "custom" });
-      expect(api.defaultReqOptions.bucket).eql("custom");
-    });
-
     it("should accept a safe option", () => {
       const api = new KintoClient(sampleRemote, { safe: true });
       expect(api._safe).eql(true);
@@ -154,9 +149,11 @@ describe("KintoClient", () => {
         batch: false,
       };
 
-      expect(api.bucket("foo", options)).to.have
-        .property("options")
-        .eql(options);
+      const bucket = api.bucket("foo", options);
+      expect(bucket).property("_safe", options.safe);
+      expect(bucket).property("_retry", options.retry);
+      expect(bucket).property("_headers").eql(options.headers);
+      expect(bucket).property("_isBatch", options.batch);
     });
   });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -70,7 +70,7 @@ describe("KintoClient", () => {
       expect(
         new KintoClient(sampleRemote, {
           headers: { Foo: "Bar" },
-        }).defaultReqOptions.headers
+        })._headers
       ).eql({ Foo: "Bar" });
     });
 
@@ -313,7 +313,7 @@ describe("KintoClient", () => {
         ];
 
         beforeEach(() => {
-          api.defaultReqOptions.headers = { Authorization: "Basic plop" };
+          api._headers = { Authorization: "Basic plop" };
           return api
             .bucket("default")
             .collection("blog")
@@ -922,7 +922,7 @@ describe("KintoClient", () => {
       });
 
       it("should support passing custom headers", () => {
-        api.defaultReqOptions.headers = { Foo: "Bar" };
+        api._headers = { Foo: "Bar" };
         api.listPermissions({ headers: { Baz: "Qux" } }).then(() => {
           sinon.assert.calledWithMatch(api.execute, {
             headers: { Foo: "Bar", Baz: "Qux" },
@@ -969,7 +969,7 @@ describe("KintoClient", () => {
     });
 
     it("should support passing custom headers", () => {
-      api.defaultReqOptions.headers = { Foo: "Bar" };
+      api._headers = { Foo: "Bar" };
       api.listBuckets({ headers: { Baz: "Qux" } });
 
       sinon.assert.calledWithMatch(
@@ -1047,7 +1047,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.defaultReqOptions.headers = { Foo: "Bar" };
+      api._headers = { Foo: "Bar" };
 
       api.createBucket("foo", { headers: { Baz: "Qux" } });
 
@@ -1100,7 +1100,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.defaultReqOptions.headers = { Foo: "Bar" };
+      api._headers = { Foo: "Bar" };
 
       api.deleteBucket("plop", { headers: { Baz: "Qux" } });
 
@@ -1136,7 +1136,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.defaultReqOptions.headers = { Foo: "Bar" };
+      api._headers = { Foo: "Bar" };
 
       return api.deleteBuckets({ headers: { Baz: "Qux" } }).then(_ => {
         sinon.assert.calledWithMatch(requests.deleteRequest, "/buckets", {

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -37,7 +37,9 @@ describe("Bucket", () => {
         headers: { Foo: "Bar" },
         safe: true,
       };
-      expect(getBlogBucket(options).options).eql(options);
+      const bucket = getBlogBucket(options);
+      expect(bucket).property("_headers", options.headers);
+      expect(bucket).property("_safe", options.safe);
     });
   });
 
@@ -131,20 +133,17 @@ describe("Bucket", () => {
     });
 
     it("should propagate bucket options", () => {
-      expect(
-        getBlogBucket({
-          headers: { Foo: "Bar" },
-          safe: true,
-        }).collection("posts", {
-          headers: { Baz: "Qux" },
-          safe: false,
-        }).options
-      ).eql({
-        headers: { Foo: "Bar", Baz: "Qux" },
-        retry: 0,
+      const collection = getBlogBucket({
+        headers: { Foo: "Bar" },
+        safe: true,
+      }).collection("posts", {
+        headers: { Baz: "Qux" },
         safe: false,
-        batch: false,
       });
+      expect(collection._headers).eql({ Foo: "Bar", Baz: "Qux" });
+      expect(collection._retry).eql(0);
+      expect(collection._safe).eql(false);
+      expect(collection._isBatch).eql(false);
     });
   });
 

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -864,6 +864,7 @@ describe("Bucket", () => {
       sinon.assert.calledWith(client.batch, fn, {
         bucket: "blog",
         headers: {},
+        safe: false,
       });
     });
 

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -140,7 +140,6 @@ describe("Bucket", () => {
           safe: false,
         }).options
       ).eql({
-        bucket: "blog",
         headers: { Foo: "Bar", Baz: "Qux" },
         safe: false,
         batch: false,

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -141,6 +141,7 @@ describe("Bucket", () => {
         }).options
       ).eql({
         headers: { Foo: "Bar", Baz: "Qux" },
+        retry: 0,
         safe: false,
         batch: false,
       });
@@ -864,6 +865,7 @@ describe("Bucket", () => {
       sinon.assert.calledWith(client.batch, fn, {
         bucket: "blog",
         headers: {},
+        retry: 0,
         safe: false,
       });
     });
@@ -879,6 +881,7 @@ describe("Bucket", () => {
       sinon.assert.calledWith(client.batch, fn, {
         bucket: "blog",
         headers: { Foo: "Bar", Baz: "Qux" },
+        retry: 0,
         safe: true,
       });
     });

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -866,6 +866,7 @@ describe("Bucket", () => {
         headers: {},
         retry: 0,
         safe: false,
+        aggregate: false,
       });
     });
 
@@ -882,6 +883,7 @@ describe("Bucket", () => {
         headers: { Foo: "Bar", Baz: "Qux" },
         retry: 0,
         safe: true,
+        aggregate: false,
       });
     });
   });

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -864,7 +864,6 @@ describe("Bucket", () => {
       sinon.assert.calledWith(client.batch, fn, {
         bucket: "blog",
         headers: {},
-        batch: false,
       });
     });
 
@@ -880,7 +879,6 @@ describe("Bucket", () => {
         bucket: "blog",
         headers: { Foo: "Bar", Baz: "Qux" },
         safe: true,
-        batch: false,
       });
     });
   });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -574,6 +574,7 @@ describe("Collection", () => {
         bucket: "blog",
         collection: "posts",
         headers: { Foo: "Bar", Baz: "Qux" },
+        retry: 0,
         safe: false,
       });
     });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -377,7 +377,12 @@ describe("Collection", () => {
           data: record,
           permissions: undefined,
         },
-        { headers: { Foo: "Bar", Baz: "Qux" }, safe: false }
+        {
+          headers: { Foo: "Bar", Baz: "Qux" },
+          safe: false,
+          last_modified: undefined,
+          patch: false,
+        }
       );
     });
 
@@ -575,6 +580,7 @@ describe("Collection", () => {
         headers: { Foo: "Bar", Baz: "Qux" },
         retry: 0,
         safe: false,
+        aggregate: false,
       });
     });
   });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -309,7 +309,7 @@ describe("Collection", () => {
           data: record,
           permissions: undefined,
         },
-        { headers: { Foo: "Bar", Baz: "Qux" } }
+        { headers: { Foo: "Bar", Baz: "Qux" }, safe: false }
       );
     });
 
@@ -377,7 +377,7 @@ describe("Collection", () => {
           data: record,
           permissions: undefined,
         },
-        { headers: { Foo: "Bar", Baz: "Qux" } }
+        { headers: { Foo: "Bar", Baz: "Qux" }, safe: false }
       );
     });
 
@@ -446,6 +446,7 @@ describe("Collection", () => {
         {
           last_modified: undefined,
           headers: { Foo: "Bar", Baz: "Qux" },
+          safe: false,
         }
       );
     });
@@ -573,6 +574,7 @@ describe("Collection", () => {
         bucket: "blog",
         collection: "posts",
         headers: { Foo: "Bar", Baz: "Qux" },
+        safe: false,
       });
     });
   });

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -520,14 +520,13 @@ describe("Collection", () => {
     });
 
     it("should support passing custom headers", () => {
-      coll.client.defaultReqOptions.headers = { Foo: "Bar" };
-      coll.listRecords({ headers: { Baz: "Qux" } });
+      coll.listRecords({ headers: { "Another-Header": "Hello" } });
 
       sinon.assert.calledWithMatch(
         coll.client.paginatedList,
         "/buckets",
         {},
-        { headers: { Foo: "Bar", Baz: "Qux" } }
+        { headers: { Foo: "Bar", Baz: "Qux", "Another-Header": "Hello" } }
       );
     });
 

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -299,7 +299,7 @@ describe("HTTP class", () => {
             .stub(global, "fetch")
             .returns(fakeServerResponse(200, {}, { "Retry-After": "1000" }));
 
-          return http.request("/", { retry: 0 }).then(_ => {
+          return http.request("/", {}, { retry: 0 }).then(_ => {
             expect(events.emit.lastCall.args[0]).eql("retry-after");
             expect(events.emit.lastCall.args[1]).eql(2000000);
           });
@@ -331,7 +331,7 @@ describe("HTTP class", () => {
             .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
           fetch.onCall(1).returns(fakeServerResponse(200, success));
           return http
-            .request("/", { retry: 1 })
+            .request("/", {}, { retry: 1 })
             .then(res => res.json)
             .should.eventually.become(success);
         });
@@ -347,7 +347,7 @@ describe("HTTP class", () => {
             .onCall(2)
             .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
           return http
-            .request("/", { retry: 2 })
+            .request("/", {}, { retry: 2 })
             .should.eventually.be.rejectedWith(Error, /HTTP 503/);
         });
       });

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -896,9 +896,10 @@ describe("Integration tests", function() {
             .should.eventually.become(["c3", "c1", "c2", "c4"]);
         });
 
-        it.only("should work in a batch", () => {
+        it("should work in a batch", () => {
           return api
             .batch(batch => batch.bucket("custom").listCollections())
+            .then(([{ body }]) => body.data.map(coll => coll.id))
             .should.eventually.become(["c4", "c3", "c2", "c1"]);
         });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -896,6 +896,12 @@ describe("Integration tests", function() {
             .should.eventually.become(["c3", "c1", "c2", "c4"]);
         });
 
+        it.only("should work in a batch", () => {
+          return api
+            .batch(batch => batch.bucket("custom").listCollections())
+            .should.eventually.become(["c4", "c3", "c2", "c1"]);
+        });
+
         describe("Filtering", () => {
           it("should filter collections", () => {
             return bucket


### PR DESCRIPTION
Per #178 and https://github.com/Kinto/kinto-admin/issues/421, kinto-admin broke when running against Kinto 7.0.0. Batch requests were being constructed with random arguments like `safe`, `retry`, and `batch`, which aren't request arguments but generic "options" for clients, buckets, and collections. Previously this wasn't a problem, but in Kinto 7.0.0, we now validate requests against a colander schema, and the colander schema doesn't recognize these options. Rather than hacking up a quick fix like 1. permitting the request schema in Kinto server to allow these unknown arguments or 2. explicitly `omit`ting these specific unknown arguments when generating requests, I took the opportunity to dive into the codebase and clarify options throughout the three classes, promoting everything out of `options` into member variables until there was nothing left to track using `options`, and then deleting `options`. This is a bit more verbose but is a lot more precise, which helps when reading and trying to track what options are sensible where.

This PR is designed to be read as a series of commits rather than as a giant diff.
