### PR TITLE
Fix undefined request options passed to fetch.

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -1,6 +1,14 @@
 "use strict";
 
-import { partition, pMap, qsify, support, nobatch, toDataBody } from "./utils";
+import {
+  partition,
+  pMap,
+  qsify,
+  support,
+  nobatch,
+  toDataBody,
+  cleanUndefinedProperties,
+} from "./utils";
 import HTTP from "./http";
 import endpoint from "./endpoint";
 import * as requests from "./requests";
@@ -387,7 +395,7 @@ export default class KintoClientBase {
     await this.fetchServerSettings();
     const result = await this.http.request(
       this.remote + request.path,
-      {
+      cleanUndefinedProperties({
         // Limit requests to only those parts that would be allowed in
         // a batch request -- don't pass through other fancy fetch()
         // options like integrity, redirect, mode because they will
@@ -396,7 +404,7 @@ export default class KintoClientBase {
         method: request.method,
         headers: request.headers,
         body: stringify ? JSON.stringify(request.body) : request.body,
-      },
+      }),
       { retry: this._getRetry(options) }
     );
     return raw ? result : result.json;

--- a/src/utils.js
+++ b/src/utils.js
@@ -315,3 +315,17 @@ export function createFormData(dataURL, body, options = {}) {
   }
   return formData;
 }
+
+/**
+ * Clones an object with all its undefined keys removed.
+ * @private
+ */
+export function cleanUndefinedProperties(obj) {
+  const result = {};
+  for (const key in obj) {
+    if (typeof obj[key] !== "undefined") {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -642,6 +642,25 @@ describe("KintoClient", () => {
     });
   });
 
+  /** @test {KintoClient#execute} */
+  describe("#execute()", () => {
+    it("should ensure passing defined allowed defined request options", () => {
+      sinon.stub(api, "fetchServerInfo").returns(Promise.resolve({}));
+      const request = sinon
+        .stub(api.http, "request")
+        .returns(Promise.resolve({}));
+
+      return api.execute({ path: "/foo", garbage: true }).then(() => {
+        sinon.assert.calledWith(
+          request,
+          "http://fake-server/v1/foo",
+          {},
+          { retry: 0 }
+        );
+      });
+    });
+  });
+
   /** @test {KintoClient#paginatedList} */
   describe("#paginatedList()", () => {
     const ETag = '"42"';

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -14,6 +14,7 @@ import {
   nobatch,
   parseDataURL,
   extractFileInfo,
+  cleanUndefinedProperties,
 } from "../src/utils";
 
 chai.should();
@@ -358,6 +359,14 @@ describe("Utils", () => {
 
       expect(blob.length).eql(4);
       expect(name).eql("t.txt");
+    });
+  });
+
+  describe("cleanUndefinedProperties()", () => {
+    it("should remove undefined properties from an object", () => {
+      const obj1 = cleanUndefinedProperties({ a: 1, b: undefined });
+      expect(obj1.hasOwnProperty("a")).eql(true);
+      expect(obj1.hasOwnProperty("b")).eql(false);
     });
   });
 });


### PR DESCRIPTION
This fixes an issue preventing request to be handled properly in Google Chrome. Chrome expects fetch options like `method` to be always defined. We may pass `undefined` instead, which results in this:

![](http://i.imgur.com/OiTOMnC.png) 

I know @glasserc loves JavaScript, so I'd really like him to review this patch.