### PR TITLE
Cleanup serverInfo a little bit

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -415,7 +415,8 @@ export default class KintoClientBase {
       this._requests.push(request);
       // Resolve with a message in case people attempt at consuming the result
       // from within a batch operation.
-      const msg = "This result is generated from within a batch " +
+      const msg =
+        "This result is generated from within a batch " +
         "operation and should not be consumed.";
       return raw ? { json: msg, headers: { get() {} } } : msg;
     }

--- a/src/base.js
+++ b/src/base.js
@@ -417,7 +417,6 @@ export default class KintoClientBase {
         "operation and should not be consumed.";
       return raw ? { json: msg, headers: { get() {} } } : msg;
     }
-    await this.fetchServerSettings();
     const result = await this.http.request(
       this.remote + request.path,
       cleanUndefinedProperties({

--- a/src/base.js
+++ b/src/base.js
@@ -240,8 +240,6 @@ export default class KintoClientBase {
    * usually performed a single time during the instance lifecycle.
    *
    * @param  {Object}  [options={}] The request options.
-   * @param  {Object}  [options.headers={}] Headers to use when making
-   *     this request.
    * @param  {Number}  [options.retry=0]    Number of retries to make
    *     when faced with transient errors.
    * @return {Promise<Object, Error>}
@@ -250,7 +248,7 @@ export default class KintoClientBase {
     if (this.serverInfo) {
       return this.serverInfo;
     }
-    this.serverInfo = await this._getHello(options);
+    this.serverInfo = await this._getHello({ retry: this._getRetry(options) });
     return this.serverInfo;
   }
 
@@ -258,6 +256,8 @@ export default class KintoClientBase {
    * Retrieves Kinto server settings.
    *
    * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
@@ -270,6 +270,8 @@ export default class KintoClientBase {
    * Retrieve server capabilities information.
    *
    * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
@@ -282,6 +284,10 @@ export default class KintoClientBase {
    * Retrieve authenticated user information.
    *
    * @param  {Object}  [options={}] The request options.
+   * @param  {Object}  [options.headers={}] Headers to use when making
+   *     this request.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")
@@ -294,6 +300,8 @@ export default class KintoClientBase {
    * Retrieve authenticated user information.
    *
    * @param  {Object}  [options={}] The request options.
+   * @param  {Number}  [options.retry=0]    Number of retries to make
+   *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   @nobatch("This operation is not supported within a batch operation.")

--- a/src/base.js
+++ b/src/base.js
@@ -323,7 +323,9 @@ export default class KintoClientBase {
     if (!requests.length) {
       return [];
     }
-    const serverSettings = await this.fetchServerSettings();
+    const serverSettings = await this.fetchServerSettings({
+      retry: this._getRetry(options),
+    });
     const maxRequests = serverSettings["batch_max_requests"];
     if (maxRequests && requests.length > maxRequests) {
       const chunks = partition(requests, maxRequests);

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -257,11 +257,14 @@ describe("KintoClient", () => {
     });
 
     function executeBatch(fixtures, options) {
-      return api.bucket("default").collection("blog").batch(batch => {
-        for (const article of fixtures) {
-          batch.createRecord(article);
-        }
-      }, options);
+      return api.bucket("default").collection("blog").batch(
+        batch => {
+          for (const article of fixtures) {
+            batch.createRecord(article);
+          }
+        },
+        options
+      );
     }
 
     describe("Batch client setup", () => {
@@ -835,11 +838,8 @@ describe("KintoClient", () => {
         const { http } = api;
         sandbox
           .stub(http, "request")
-          // settings retrieval
-          .onFirstCall()
-          .returns(Promise.resolve({ json: { settings: {} } }))
           // first page
-          .onSecondCall()
+          .onFirstCall()
           .returns(
             Promise.resolve({
               headers: { get: () => "http://next-page/" },
@@ -847,7 +847,7 @@ describe("KintoClient", () => {
             })
           )
           // second page
-          .onThirdCall()
+          .onSecondCall()
           .returns(
             Promise.resolve({
               headers: { get: () => {} },
@@ -865,11 +865,8 @@ describe("KintoClient", () => {
         const { http } = api;
         sandbox
           .stub(http, "request")
-          // settings retrieval
-          .onFirstCall()
-          .returns(Promise.resolve({ json: { settings: {} } }))
           // first page
-          .onSecondCall()
+          .onFirstCall()
           .returns(
             Promise.resolve({
               headers: { get: () => "http://next-page/" },
@@ -887,11 +884,8 @@ describe("KintoClient", () => {
         const { http } = api;
         sandbox
           .stub(http, "request")
-          // settings retrieval
-          .onFirstCall()
-          .returns(Promise.resolve({ json: { settings: {} } }))
           // first page
-          .onSecondCall()
+          .onFirstCall()
           .returns(
             Promise.resolve({
               headers: { get: () => "1337" },

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -257,14 +257,11 @@ describe("KintoClient", () => {
     });
 
     function executeBatch(fixtures, options) {
-      return api.bucket("default").collection("blog").batch(
-        batch => {
-          for (const article of fixtures) {
-            batch.createRecord(article);
-          }
-        },
-        options
-      );
+      return api.bucket("default").collection("blog").batch(batch => {
+        for (const article of fixtures) {
+          batch.createRecord(article);
+        }
+      }, options);
     }
 
     describe("Batch client setup", () => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -549,11 +549,10 @@ describe("Collection", () => {
         sandbox.restore();
         sandbox.stub(global, "setTimeout", fn => setImmediate(fn));
         const fetch = sandbox.stub(global, "fetch");
-        fetch.onCall(0).returns(fakeServerResponse(200, {}));
         fetch
-          .onCall(1)
+          .onCall(0)
           .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-        fetch.onCall(2).returns(fakeServerResponse(200, response));
+        fetch.onCall(1).returns(fakeServerResponse(200, response));
       });
 
       it("should retry the request if option is specified", () => {


### PR DESCRIPTION
Try to clean up some of the warts around the use of `serverInfo`. In particular:

- Don't memoize the result of `fetchUser`, since it can change in the presence of authentication information.
- Forbid the passing of `headers` to `fetchServerInfo`, since it doesn't make any sense (the server information shouldn't change according to the presence of authentication information).
- Get rid of a needless `fetchServerSettings` in `execute()`.
- Pass `retry` to one call to `fetchServerSettings` that didn't have it.

This doesn't completely clean it up; `retry` isn't passed in calls made via `capable()` or `support()`, and I don't see a way to make it be. Honestly I'd prefer to get rid of `retry` as an option on every single method, but that's a separate discussion.

Fixes #181 and responds to https://github.com/Kinto/kinto-http.js/pull/174#discussion_r107751608.