### PR TITLE
EventEmitter was moved

### DIFF
--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -21,7 +21,7 @@ const Cu = Components.utils;
 
 Cu.import("resource://gre/modules/Timer.jsm");
 Cu.importGlobalProperties(['fetch']);
-const { EventEmitter } = Cu.import("resource://devtools/shared/event-emitter.js", {});
+const { EventEmitter } = Cu.import("resource://gre/modules/EventEmitter.jsm", {});
 
 export default class KintoHttpClient extends KintoClientBase {
   constructor(remote, options={}) {


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1356231, devtools is
going away. Update kinto-http.js to match.

Probably this is a signal that we shouldn't have Firefox-specific goop
in this repo.