### PR TITLE
Fix intermittent test

### DIFF
--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -1417,10 +1417,9 @@ describe("Integration tests", function() {
 
           describe(".removePermissions()", () => {
             beforeEach(() => {
-              return Promise.all([
-                coll.setPermissions({ read: ["github:n1k0"] }),
-                coll.setData({ a: 1 }),
-              ]);
+              return coll
+                .setPermissions({ read: ["github:n1k0"] })
+                .then(() => coll.setData({ a: 1 }));
             });
 
             it("should pop collection permissions", () => {


### PR DESCRIPTION
There appears to be a race condition here (see
https://github.com/Kinto/kinto/issues/1290), although this being the
memory backend, we probably shouldn't expect anything robust. Work
around it by making requests sequentially.