### PR TITLE
Turn eslint dependency into range dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "coveralls": "^2.11.16",
     "esdoc": "^1.0.1",
     "esdoc-importpath-plugin": "1.0.1",
-    "eslint": "4.7.1",
+    "eslint": "^4.7.2",
     "form-data": "^2.1.2",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^11.0.0",


### PR DESCRIPTION
This got pinned to a specific version in
b3d4e280c3f66ceea496c4368546d602c6c11916 to work around a temporary
breakage that seems to have been resolved at some point in the
intervening 18 months. Most eslint versions have not caused breakage.

Closes #237.