### PR TITLE
Ensure that KINTO_EOS is a string

### DIFF
--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -562,7 +562,7 @@ describe("Integration tests", function() {
           .toJSON()
           .slice(0, 10);
         return startServer(server, {
-          KINTO_EOS: tomorrow,
+          KINTO_EOS: `"${tomorrow}"`,
           KINTO_EOS_URL: "http://www.perdu.com",
           KINTO_EOS_MESSAGE: "Boom",
         });
@@ -589,7 +589,7 @@ describe("Integration tests", function() {
           .toJSON()
           .slice(0, 10);
         return startServer(server, {
-          KINTO_EOS: lastWeek,
+          KINTO_EOS: `"${lastWeek}"`,
           KINTO_EOS_URL: "http://www.perdu.com",
           KINTO_EOS_MESSAGE: "Boom",
         });


### PR DESCRIPTION
Kinto's environment parsing logic runs this through native_value,
which tries to parse it using ast.literal_eval, which interprets the
string "2017-10-30" as the mathematical expression 2017-10-30, which
is 1977.

This code has been in place for a long time so it isn't clear how it
ever worked. ast.literal_eval has behaved this way since at least
2014.

In Kinto 7.x, we stopped using literal_eval for native values and
instead use json.loads, which of course can't parse 2017-10-30, which
leads us to fall back to using the string as a string. So the recent
test failures we've been seeing have only affected Kinto 6.0.4.

One reason why this seems to have been working up until very recently
is that 2017-10-10 is the first date since 2016-12-31 where one of the
"operands" didn't start with a 0, which is syntactically illegal in
Python, causing ast.literal_eval to fail to parse it and letting us
fall back to a string. However, even in late 2016-12, we were seeing
tests pass and it still isn't clear why. Neither this test code, nor
the environment-parsing logic, is any different in Kinto 5.1.0 (which
is what we tested against in those days).

This workaround will force interpretation as a string, even though it
isn't strictly necessary for Kinto 7.x.

This is the same basic fix as Kinto/kinto.js#770, but is necessary here too in order to fix issues like #247.