### PR TITLE
Firefox updates

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,9 +14,6 @@
     "firefox": {
       "plugins": [
         "babel-plugin-transform-decorators-legacy",
-        ["babel-plugin-transform-builtin-extend", {
-          "globals": ["Error"]
-        }],
         "transform-es2015-modules-commonjs",
         "transform-object-rest-spread"
       ]

--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -21,14 +21,17 @@ import * as errors from "../src/errors";
 const Cu = Components.utils;
 
 Cu.import("resource://gre/modules/Timer.jsm");
-Cu.importGlobalProperties(['fetch']);
-const { EventEmitter } = Cu.import("resource://gre/modules/EventEmitter.jsm", {});
+Cu.importGlobalProperties(["fetch"]);
+const { EventEmitter } = Cu.import(
+  "resource://gre/modules/EventEmitter.jsm",
+  {}
+);
 
 export default class KintoHttpClient extends KintoClientBase {
-  constructor(remote, options={}) {
+  constructor(remote, options = {}) {
     const events = {};
     EventEmitter.decorate(events);
-    super(remote, {events, ...options});
+    super(remote, { events, ...options });
   }
 }
 

--- a/fx-src/index.js
+++ b/fx-src/index.js
@@ -16,6 +16,7 @@
 "use strict";
 
 import KintoClientBase from "../src/base";
+import * as errors from "../src/errors";
 
 const Cu = Components.utils;
 
@@ -30,6 +31,8 @@ export default class KintoHttpClient extends KintoClientBase {
     super(remote, {events, ...options});
   }
 }
+
+KintoHttpClient.errors = errors;
 
 // This fixes compatibility with CommonJS required by browserify.
 // See http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default/33683495#33683495

--- a/src/errors.js
+++ b/src/errors.js
@@ -27,8 +27,10 @@ const ERROR_CODES = {
 export default ERROR_CODES;
 
 class NetworkTimeoutError extends Error {
-  constructor(url, options, ...params) {
-    super(...params);
+  constructor(url, options) {
+    super(
+      `Timeout while trying to access ${url} with ${JSON.stringify(options)}`
+    );
 
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, NetworkTimeoutError);

--- a/src/errors.js
+++ b/src/errors.js
@@ -30,7 +30,9 @@ class NetworkTimeoutError extends Error {
   constructor(url, options, ...params) {
     super(...params);
 
-    Error.captureStackTrace(this, NetworkTimeoutError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, NetworkTimeoutError);
+    }
 
     this.url = url;
     this.options = options;
@@ -46,7 +48,10 @@ class UnparseableResponseError extends Error {
         body
       }`
     );
-    Error.captureStackTrace(this, UnparseableResponseError);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UnparseableResponseError);
+    }
 
     this.status = status;
     this.response = response;
@@ -96,7 +101,9 @@ class ServerResponse extends Error {
     }
 
     super(message.trim());
-    Error.captureStackTrace(this, ServerResponse);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ServerResponse);
+    }
 
     this.response = response;
     this.data = json;


### PR DESCRIPTION
While working on https://bugzilla.mozilla.org/show_bug.cgi?id=1388830 and https://bugzilla.mozilla.org/show_bug.cgi?id=1415222, I discovered that actually using the exception classes from 4.4.0 didn't actually work. This PR represents some of the changes I've had to make in order to get things closer to working in Gecko.