### PR TITLE
Use transform-runtime to request regenerator without depending on it

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,10 @@
           "globals": ["Error"]
         }],
         "transform-object-rest-spread",
-        "transform-async-to-generator"
+        "transform-async-to-generator",
+        ["transform-runtime", {
+          "polyfill": false
+        }]
       ]
     },
     "firefox": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/Kinto/kinto-http.js#readme",
   "dependencies": {
+    "babel-runtime": "^6.22.0",
     "uuid": "^3.0.1"
   },
   "devDependencies": {
@@ -55,7 +56,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
-    "babel-polyfill": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babelify": "^8.0.0",
     "browserify": "^14.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,5 @@
 "use strict";
 
-// babel-polyfill can only be imported once
-if (!global._babelPolyfill) {
-  require("babel-polyfill");
-}
-
 import { EventEmitter } from "events";
 
 import KintoClientBase from "./base";


### PR DESCRIPTION
[transform-runtime](https://babeljs.io/docs/plugins/transform-runtime) is meant to allow us to access the regenerator
polyfill "seamlessly, without global pollution". This means we don't
need to import it explicitly, and we don't need to make any efforts to
import it only once.

This replaces babel-polyfill, which is meant for applications, not
libraries.

Applications are responsible for providing the polyfill.

We use the "polyfill: false" option to disable conversion of "builtin"
JS methods such as Array.from and Object.create, which we could also
rewrite except for
https://github.com/loganfsmyth/babel-plugin-transform-builtin-extend/issues/15.

This is meant to fix #259 and Kinto/kinto#1379.

Refs #159 (cc: @screendriver).

Refs Kinto/kinto-admin#456 and Kinto/kinto-admin#446.