### PR TITLE
Tests use accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ const kinto = new KintoClient("https://my.server.tld/v1", {
 
 > #### Notes
 >
-> - As explained in the [server docs](http://kinto.readthedocs.io/en/stable/api/1.x/authentication.html#basic-auth), any string is accepted. You're not obliged to use the `username:password` format.
+> - As Kinto Accounts has become the default as of 11, you may need to create an account first.
 
 ### Using an OAuth Bearer Token
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -87,7 +87,9 @@ describe("Integration tests", function() {
       return stopServer(server);
     });
 
-    beforeEach(() => server.flush());
+    beforeEach(() => {
+      return server.flush().then(_ => api.createAccount("user", "pass"));
+    });
 
     // XXX move this to batch tests
     describe("new batch", () => {
@@ -152,7 +154,7 @@ describe("Integration tests", function() {
 
       it("should retrieve user information", () => {
         return api.fetchUser().then(user => {
-          expect(user.id).to.match(/^basicauth:/);
+          expect(user.id).to.equal("account:user");
           expect(user.bucket).to.have.length.of(36);
         });
       });
@@ -319,6 +321,8 @@ describe("Integration tests", function() {
               expect(bucketCreate.length).eql(1);
               data = data.filter(p => !isBucketCreate(p));
             }
+            const isOwnAccount = p => p.uri == "/accounts/user";
+            data = data.filter(p => !isOwnAccount(p));
             expect(data).to.have.length.of(2);
             expect(data.map(p => p.id).sort()).eql(["b1", "c1"]);
           });
@@ -340,6 +344,7 @@ describe("Integration tests", function() {
             if (shouldHaveCreatePermission) {
               expectedRecords++;
             }
+            expectedRecords++; // for account:create
             expect(results.data).to.have.length.of(expectedRecords);
           });
         });
@@ -575,7 +580,9 @@ describe("Integration tests", function() {
 
     after(() => stopServer(server));
 
-    beforeEach(() => server.flush());
+    beforeEach(() => {
+      return server.flush().then(_ => api.createAccount("user", "pass"));
+    });
 
     it("should appropriately populate the backoff property", () => {
       // Issuing a first api call to retrieve backoff information
@@ -586,8 +593,6 @@ describe("Integration tests", function() {
   });
 
   describe("Deprecated protocol version", () => {
-    beforeEach(() => server.flush());
-
     describe("Soft EOL", () => {
       before(() => {
         const tomorrow = new Date(new Date().getTime() + 86400000)
@@ -646,7 +651,9 @@ describe("Integration tests", function() {
 
     after(() => stopServer(server));
 
-    beforeEach(() => server.flush());
+    beforeEach(() => {
+      return server.flush().then(_ => api.createAccount("user", "pass"));
+    });
 
     describe("Limited configured server pagination", () => {
       let collection;
@@ -680,7 +687,9 @@ describe("Integration tests", function() {
 
     after(() => stopServer(server));
 
-    beforeEach(() => server.flush());
+    beforeEach(() => {
+      return server.flush().then(_ => api.createAccount("user", "pass"));
+    });
 
     describe(".bucket()", () => {
       let bucket;

--- a/test/kinto-8.1.2.ini
+++ b/test/kinto-8.1.2.ini
@@ -1,9 +1,6 @@
 [app:main]
 use = egg:kinto
 
-# Required by basic auth
-kinto.userid_hmac_secret = a-secret-string
-
 # Allow browsing all buckets
 kinto.bucket_read_principals = system.Authenticated
 
@@ -25,7 +22,7 @@ kinto.attachment.extensions = any
 kinto.experimental_permissions_endpoint = True
 
 # Force accounts (not default until 10.2)
-multiauth.policies = account basicauth
+multiauth.policies = account
 multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
 kinto.account_create_principals = system.Everyone
 

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -1,12 +1,6 @@
 [app:main]
 use = egg:kinto
 
-# Required by integration tests
-kinto.flush_endpoint_enabled = true
-
-# Required by basic auth
-kinto.userid_hmac_secret = a-secret-string
-
 # Allow browsing all buckets
 kinto.bucket_read_principals = system.Authenticated
 
@@ -27,7 +21,7 @@ kinto.attachment.extensions = any
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
 
-multiauth.policies = account basicauth
+multiauth.policies = account
 multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
 kinto.account_create_principals = system.Everyone
 


### PR DESCRIPTION
Since Kinto/kinto#1736 landed, the test suite for both this library and kinto.js have been failing constantly (see e.g. #300, #301, #302, #303). Here is a fix which moves all tests to using accounts which should fix it.

Note that with this fix, the test suite takes a lot longer -- over 20 minutes on my laptop. I'm not exactly sure why but I bet it's due to the increased need for cryptographically hashing passwords once per request. Of special note is `should handle long list of changes`, which took almost 2 minutes on my machine. Maybe @leplatrem can make it faster on master, and maybe we should leave it on basicauth for the older kintos?