### PR TITLE
Force basicauth in tests on master

### DIFF
--- a/test/kinto-6.0.1.ini
+++ b/test/kinto-6.0.1.ini
@@ -20,6 +20,7 @@ kinto.attachment.base_url = http://0.0.0.0:8888/attachments
 kinto.attachment.folder = {bucket_id}/{collection_id}
 kinto.attachment.keep_old_files = true
 kinto.attachment.base_path = /tmp
+kinto.attachment.extensions = any
 
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -21,6 +21,7 @@ kinto.attachment.base_url = http://0.0.0.0:8888/attachments
 kinto.attachment.folder = {bucket_id}/{collection_id}
 kinto.attachment.keep_old_files = true
 kinto.attachment.base_path = /tmp
+kinto.attachment.extensions = any
 
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -25,6 +25,8 @@ kinto.attachment.base_path = /tmp
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
 
+multiauth.policies = basicauth
+
 kinto.paginate_by = 10
 
 [server:main]


### PR DESCRIPTION
This is another crack at #304. Rather than move everything to accounts as the One True Path, let's just try to stop the bleeding (where bleeding = constantly failing tests), and then roll in other stuff as necessary.