### PR TITLE
Add support for query arguments to Collection#getData

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -3,6 +3,7 @@ import { v4 as uuid } from "uuid";
 import { capable, toDataBody, isObject } from "./utils";
 import * as requests from "./requests";
 import endpoint from "./endpoint";
+import { qsify } from "./utils";
 
 /**
  * Abstract representation of a selected collection.
@@ -118,12 +119,19 @@ export default class Collection {
    *
    * @param  {Object} [options={}]      The options object.
    * @param  {Object} [options.headers] The headers object option.
+   * @param  {Object} [options.query]   Query parameters to pass in
+   *     the request. This might be useful for features that aren't
+   *     yet supported by this library.
    * @param  {Number} [options.retry=0] Number of retries to make
    *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
   async getData(options = {}) {
-    const path = endpoint("collection", this.bucket.name, this.name);
+    let path = endpoint("collection", this.bucket.name, this.name);
+    if (options.query) {
+      const querystring = qsify(options.query);
+      path = path + "?" + querystring;
+    }
     const request = { headers: this._getHeaders(options), path };
     const { data } = await this.client.execute(request, {
       retry: this._getRetry(options),

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -85,6 +85,16 @@ describe("Collection", () => {
         .getData()
         .should.become({ foo: "bar" });
     });
+
+    it("should pass filters through", () => {
+      sandbox.stub(client, "execute").returns(Promise.resolve());
+
+      getBlogPostsCollection().getData({ query: { _expected: '"123"' } });
+
+      sinon.assert.calledWithMatch(client.execute, {
+        path: "/buckets/blog/collections/posts?_expected=%22123%22",
+      });
+    });
   });
 
   /** @test {Collection#getPermissions} */


### PR DESCRIPTION
Ref #307.

This represents a minimal change that fixes the issue. In particular, it doesn't add support for `_fields` (which should probably be supported as a separate `option`) and it doesn't add support to query arguments for buckets, records, or groups (are there other resources too?). The goal of this PR is to land just this feature for the purposes of getting uplifted.
