### PR TITLE
Add accounts support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 - ACTION="run lint"
 - ACTION="run dist" # ensures building dist files doesn't break
 - ACTION="run cs-check"
-- SERVER=6.0.1 ACTION=test
+- SERVER=8.1.2 ACTION=test
 - SERVER=master ACTION=test
 before_install:
 - export PATH=$HOME/.local/bin:$PATH

--- a/src/base.js
+++ b/src/base.js
@@ -684,4 +684,15 @@ export default class KintoClientBase {
       { retry: this._getRetry(options) }
     );
   }
+
+  @capable(["accounts"])
+  async createAccount(username, password) {
+    return this.execute(
+      requests.createRequest(
+        `/accounts/${username}`,
+        { data: { password } },
+        { method: "PUT" }
+      )
+    );
+  }
 }

--- a/src/requests.js
+++ b/src/requests.js
@@ -30,8 +30,9 @@ export function createRequest(path, { data, permissions }, options = {}) {
     ...requestDefaults,
     ...options,
   };
+  const method = options.method || (data && data.id) ? "PUT" : "POST";
   return {
-    method: data && data.id ? "PUT" : "POST",
+    method: method,
     path,
     headers: { ...headers, ...safeHeader(safe) },
     body: { data, permissions },

--- a/src/requests.js
+++ b/src/requests.js
@@ -32,7 +32,7 @@ export function createRequest(path, { data, permissions }, options = {}) {
   };
   const method = options.method || (data && data.id) ? "PUT" : "POST";
   return {
-    method: method,
+    method,
     path,
     headers: { ...headers, ...safeHeader(safe) },
     body: { data, permissions },

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -301,6 +301,11 @@ describe("Integration tests", function() {
       // up to one where it also has bucket:create, we can clean this
       // up.
       let shouldHaveBucketCreate =
+        // People developing don't always set SERVER. Let's assume
+        // that means "master".
+        !process.env.SERVER ||
+        // "master" is greater than 8.3 but let's just be explicit here.
+        process.env.SERVER == "master" ||
         process.env.SERVER > "8.3" ||
         (process.env.SERVER > "8.2" && process.env.SERVER.includes("dev"));
       describe("Single page of permissions", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -441,6 +441,21 @@ describe("Integration tests", function() {
       });
     });
 
+    describe("#createAccount", () => {
+      it("should create an account", () => {
+        return api
+          .createAccount("testuser", "testpw")
+          .then(() =>
+            createClient({
+              headers: { Authorization: "Basic " + btoa("testuser:testpw") },
+            }).fetchUser()
+          )
+          .then(user => {
+            expect(user.id).equal("account:testuser");
+          });
+      });
+    });
+
     describe("#batch", () => {
       describe("No chunked requests", () => {
         it("should allow batching operations", () => {

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -300,7 +300,7 @@ describe("Integration tests", function() {
       // version (see .travis.yml). If we ever bump the older version
       // up to one where it also has bucket:create, we can clean this
       // up.
-      let shouldHaveBucketCreate =
+      let shouldHaveCreatePermission =
         // People developing don't always set SERVER. Let's assume
         // that means "master".
         !process.env.SERVER ||
@@ -318,12 +318,12 @@ describe("Integration tests", function() {
 
         it("should retrieve the list of permissions", () => {
           return api.listPermissions().then(({ data }) => {
-            if (shouldHaveBucketCreate) {
-              // One element is `bucket:create` which doesn't refer to
-              // any particular id. Remove it.
+            if (shouldHaveCreatePermission) {
+              // One element is for the root element which has
+              // `bucket:create` as well as `account:create`. Remove
+              // it.
               const isBucketCreate = p =>
-                p.permissions.length == 1 &&
-                p.permissions[0] === "bucket:create";
+                p.permissions.includes("bucket:create");
               const bucketCreate = data.filter(isBucketCreate);
               expect(bucketCreate.length).eql(1);
               data = data.filter(p => !isBucketCreate(p));
@@ -346,7 +346,7 @@ describe("Integration tests", function() {
         it("should retrieve the list of permissions", () => {
           return api.listPermissions({ pages: Infinity }).then(results => {
             let expectedRecords = 15;
-            if (shouldHaveBucketCreate) {
+            if (shouldHaveCreatePermission) {
               expectedRecords++;
             }
             expect(results.data).to.have.length.of(expectedRecords);

--- a/test/kinto-8.1.2.ini
+++ b/test/kinto-8.1.2.ini
@@ -11,6 +11,7 @@ kinto.bucket_read_principals = system.Authenticated
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
+                 kinto.plugins.accounts
                  kinto.plugins.flush
 
 # Kinto-attachment
@@ -22,6 +23,11 @@ kinto.attachment.extensions = any
 
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
+
+# Force accounts (not default until 10.2)
+multiauth.policies = account basicauth
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+kinto.account_create_principals = system.Everyone
 
 kinto.paginate_by = 10
 

--- a/test/kinto-8.1.2.ini
+++ b/test/kinto-8.1.2.ini
@@ -1,9 +1,6 @@
 [app:main]
 use = egg:kinto
 
-# Required by integration tests
-kinto.flush_endpoint_enabled = true
-
 # Required by basic auth
 kinto.userid_hmac_secret = a-secret-string
 
@@ -14,6 +11,7 @@ kinto.bucket_read_principals = system.Authenticated
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
+                 kinto.plugins.flush
 
 # Kinto-attachment
 kinto.attachment.base_url = http://0.0.0.0:8888/attachments

--- a/test/kinto.ini
+++ b/test/kinto.ini
@@ -14,6 +14,7 @@ kinto.bucket_read_principals = system.Authenticated
 kinto.includes = kinto.plugins.default_bucket
                  kinto.plugins.history
                  kinto_attachment
+                 kinto.plugins.accounts
                  kinto.plugins.flush
 
 # Kinto-attachment
@@ -26,7 +27,9 @@ kinto.attachment.extensions = any
 # Enable permissions endpoint
 kinto.experimental_permissions_endpoint = True
 
-multiauth.policies = basicauth
+multiauth.policies = account basicauth
+multiauth.policy.account.use = kinto.plugins.accounts.authentication.AccountsAuthenticationPolicy
+kinto.account_create_principals = system.Everyone
 
 kinto.paginate_by = 10
 


### PR DESCRIPTION
This is meant to extract the part of #304 that adds a `createAccount` method, and nothing besides that.

I had a horrible realization when I was writing this that when adding the `accounts` plugin was going to make the entire test suite slow, even for those tests that do `basicauth`. Fortunately, it doesn't; see https://github.com/Kinto/kinto/issues/1821. Still, we might want to hold off on merging this until we figure out our plan for that bug.

Another option might be to use a separate config for just the account tests. But then we might have to have two, one for each Kinto version..