### PR TITLE
Restore use of versions.txt when installing master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
- - "3.5"
+ - "3.6"
 env:
 - ACTION="run lint"
 - ACTION="run dist" # ensures building dist files doesn't break

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - npm install
 - curl https://raw.githubusercontent.com/Kinto/kinto/master/requirements.txt > versions.txt
 - if [[ $SERVER && $SERVER != "master" ]]; then pip install kinto==$SERVER; fi
-- if [[ $SERVER && $SERVER == "master" ]]; then pip install https://github.com/Kinto/kinto/zipball/master; fi
+- if [[ $SERVER && $SERVER == "master" ]]; then pip install https://github.com/Kinto/kinto/zipball/master --constraint versions.txt; fi
 - pip install https://github.com/Kinto/kinto-attachment/zipball/master
 - export KINTO_PSERVE_EXECUTABLE=pserve
 script:


### PR DESCRIPTION
This got dropped soon after it got added, but it seems like this is
why we fetch versions.txt. It's my hope that putting this back in will
cause tests to pass (right now they're failing because kinto relies on
jsonschema==3.0.0a3 and we're installing 2.6.0).