### PR TITLE
Remove support for the Total-Records header on GET

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -522,7 +522,7 @@ export default class KintoClientBase {
       return handleResponse(await this.http.request(nextPage, { headers }));
     };
 
-    const pageResults = (results, nextPage, etag, totalRecords) => {
+    const pageResults = (results, nextPage, etag) => {
       // ETag string is supposed to be opaque and stored «as-is».
       // ETag header values are quoted (because of * and W/"foo").
       return {
@@ -530,24 +530,22 @@ export default class KintoClientBase {
         data: results,
         next: next.bind(null, nextPage),
         hasNextPage: !!nextPage,
-        totalRecords,
       };
     };
 
     const handleResponse = async function({ headers, json }) {
       const nextPage = headers.get("Next-Page");
       const etag = headers.get("ETag");
-      const totalRecords = parseInt(headers.get("Total-Records"), 10);
 
       if (!pages) {
-        return pageResults(json.data, nextPage, etag, totalRecords);
+        return pageResults(json.data, nextPage, etag);
       }
       // Aggregate new results with previous ones
       results = results.concat(json.data);
       current += 1;
       if (current >= pages || !nextPage) {
         // Pagination exhausted
-        return pageResults(results, nextPage, etag, totalRecords);
+        return pageResults(results, nextPage, etag);
       }
       // Follow next page
       return processNextPage(nextPage);

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -700,7 +700,6 @@ describe("KintoClient", () => {
   /** @test {KintoClient#paginatedList} */
   describe("#paginatedList()", () => {
     const ETag = '"42"';
-    const totalRecords = 1337;
     const path = "/some/path";
 
     describe("No pagination", () => {
@@ -713,8 +712,6 @@ describe("KintoClient", () => {
               get: name => {
                 if (name === "ETag") {
                   return ETag;
-                } else if (name === "Total-Records") {
-                  return String(totalRecords);
                 }
               },
             },
@@ -747,13 +744,6 @@ describe("KintoClient", () => {
           .paginatedList(path)
           .should.eventually.have.property("data")
           .eql([{ a: 1 }]);
-      });
-
-      it("should resolve with number of total records", () => {
-        return api
-          .paginatedList(path)
-          .should.eventually.have.property("totalRecords")
-          .eql(1337);
       });
 
       it("should resolve with a next() function", () => {
@@ -920,25 +910,6 @@ describe("KintoClient", () => {
           .paginatedList(path)
           .should.eventually.have.property("hasNextPage")
           .eql(true);
-      });
-
-      it("should resolve with number of total records", () => {
-        const { http } = api;
-        sandbox
-          .stub(http, "request")
-          // first page
-          .onFirstCall()
-          .returns(
-            Promise.resolve({
-              headers: { get: () => "1337" },
-              json: { data: [1, 2] },
-            })
-          );
-
-        return api
-          .paginatedList(path)
-          .should.eventually.have.property("totalRecords")
-          .eql(1337);
       });
     });
 

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -341,7 +341,6 @@ describe("Integration tests", function() {
               expectedRecords++;
             }
             expect(results.data).to.have.length.of(expectedRecords);
-            expect(results.totalRecords).eql(expectedRecords);
           });
         });
       });
@@ -1770,15 +1769,6 @@ describe("Integration tests", function() {
                 .then(_ => coll.listRecords())
                 .then(({ data }) => data.map(record => record.title))
                 .should.become(["foo"]);
-            });
-
-            it("should expose the total number of records", () => {
-              return coll
-                .createRecord({ a: 1 })
-                .then(() => coll.createRecord({ a: 2 }))
-                .then(() => coll.listRecords())
-                .should.eventually.have.property("totalRecords")
-                .eql(2);
             });
 
             it("should order records by field", () => {


### PR DESCRIPTION
This got removed in https://github.com/Kinto/kinto/pull/1931, and has
been causing failing tests ever since.

This appears to be the cause of build failures in https://github.com/Kinto/kinto-http.js/issues/320 and #321.

Fixes #322.