### PR TITLE
 Support for retrieving ETag (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Read the [API documentation](https://doc.esdoc.org/github.com/Kinto/kinto-http.j
      - [Updating an existing group](#updating-an-existing-group)
      - [Deleting a group](#deleting-a-group)
      - [Listing bucket history](#listing-bucket-history)
+     - [Bucket ETag](#bucket-etag)
   - [Collections](#collections)
      - [Selecting a collection](#selecting-a-collection)
      - [Getting collection data](#getting-collection-data)
@@ -50,6 +51,7 @@ Read the [API documentation](https://doc.esdoc.org/github.com/Kinto/kinto-http.j
      - [Deleting record](#deleting-record)
      - [Listing records](#listing-records)
      - [Total number of records](#total-number-of-records)
+     - [Collection ETag](#collection-etag)
      - [Batching operations](#batching-operations)
   - [Listing all resource permissions](#listing-all-resource-permissions)
   - [Attachments](#attachments)
@@ -853,6 +855,27 @@ Sample result:
 
 This method accepts the [generic parameters for sorting, filtering and paginating results](#generic-options-for-list-operations).
 
+### Bucket ETag
+
+The bucket ETag is used for the `since` option in the [generic parameters for sorting, filtering and
+paginating results](#generic-options-for-list-operations) when dealing with buckets.
+
+```js
+const result = await client.bucket("blog")
+  .getETag();
+```
+
+Sample result:
+
+```js
+"1548699177099"
+```
+
+#### options
+
+- `headers`: custom headers object to send along the http request
+- `retry`: number of retries when request fails (default: 0)
+
 
 ## Collections
 
@@ -1142,7 +1165,7 @@ Sample result:
 
 The result object exposes the following properties:
 
-- `last_modified`: the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html). This value is opaque and should be reused as is, eg. passing it as a `since` option (see [Generic bucket and collection options](#generic-bucket-and-collection-options))
+- `last_modified`: the [collection's timestamp](http://kinto.readthedocs.io/en/stable/api/1.x/timestamps.html).
 - `next`: the [pagination](#paginating-results) helper to access the next page of results, if any
 - `totalRecords`: the total number of records in the **entire collection**. This number can alternatively be retrieved using the `getTotalRecords()` method of the collection API
 - `data`: the list of records
@@ -1168,10 +1191,31 @@ Sample result:
 42
 ```
 
-#### Options
+#### options
 
-- `headers`: Custom headers object to send along the HTTP request
-- `retry`: Number of retries when request fails (default: 0)
+- `headers`: custom headers object to send along the http request
+- `retry`: number of retries when request fails (default: 0)
+
+### Collection ETag
+
+The collection ETag is used for the `since` option in the [generic parameters for sorting, filtering
+and paginating results](#generic-options-for-list-operations) when dealing with collections.
+
+```js
+const result = await client.bucket("blog").collection("posts")
+  .getETag();
+```
+
+Sample result:
+
+```js
+"1548699177099"
+```
+
+#### options
+
+- `headers`: custom headers object to send along the http request
+- `retry`: number of retries when request fails (default: 0)
 
 ### Batching operations
 

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -94,6 +94,29 @@ export default class Bucket {
   }
 
   /**
+   * Retrieves the ETag of the collection, for use with the `since` filtering option.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<String, Error>}
+   */
+  async getETag(options = {}) {
+    const path = endpoint("bucket", this.name);
+    const request = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    });
+    return headers.get("ETag");
+  }
+
+  /**
    * Retrieves bucket data.
    *
    * @param  {Object} [options={}]      The options object.

--- a/src/collection.js
+++ b/src/collection.js
@@ -115,6 +115,29 @@ export default class Collection {
   }
 
   /**
+   * Retrieves the ETag of the collection, for use with the `since` filtering option.
+   *
+   * @param  {Object} [options={}]      The options object.
+   * @param  {Object} [options.headers] The headers object option.
+   * @param  {Number} [options.retry=0] Number of retries to make
+   *     when faced with transient errors.
+   * @return {Promise<String, Error>}
+   */
+  async getETag(options = {}) {
+    const path = endpoint("record", this.bucket.name, this.name);
+    const request = {
+      headers: this._getHeaders(options),
+      path,
+      method: "HEAD",
+    };
+    const { headers } = await this.client.execute(request, {
+      raw: true,
+      retry: this._getRetry(options),
+    });
+    return headers.get("ETag");
+  }
+
+  /**
    * Retrieves collection data.
    *
    * @param  {Object} [options={}]      The options object.

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -40,6 +40,38 @@ describe("Bucket", () => {
     });
   });
 
+  /** @test {Bucket#getETag} */
+  describe("#getETag()", () => {
+    it("should execute expected request", () => {
+      sandbox.stub(client, "execute").returns(Promise.resolve());
+
+      getBlogBucket().getETag();
+
+      sinon.assert.calledWithMatch(
+        client.execute,
+        { method: "HEAD", path: "/buckets/blog" },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the ETag header value", () => {
+      const etag = '"tag"';
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get(value) {
+              return value == "ETag" ? etag : null;
+            },
+          },
+        })
+      );
+
+      return getBlogBucket()
+        .getETag()
+        .should.become(etag);
+    });
+  });
+
   /** @test {Bucket#getData} */
   describe("#getData()", () => {
     it("should execute expected request", () => {

--- a/test/collection_test.js
+++ b/test/collection_test.js
@@ -65,6 +65,38 @@ describe("Collection", () => {
     });
   });
 
+  /** @test {Collection#getETag} */
+  describe("#getETag()", () => {
+    it("should execute expected request", () => {
+      sandbox.stub(client, "execute").returns(Promise.resolve());
+
+      getBlogPostsCollection().getETag();
+
+      sinon.assert.calledWithMatch(
+        client.execute,
+        { method: "HEAD", path: "/buckets/blog/collections/posts/records" },
+        { raw: true }
+      );
+    });
+
+    it("should resolve with the ETag header value", () => {
+      const etag = '"tag"';
+      sandbox.stub(client, "execute").returns(
+        Promise.resolve({
+          headers: {
+            get(value) {
+              return value == "ETag" ? etag : null;
+            },
+          },
+        })
+      );
+
+      return getBlogPostsCollection()
+        .getETag()
+        .should.become(etag);
+    });
+  });
+
   /** @test {Collection#getData} */
   describe("#getData()", () => {
     it("should execute expected request", () => {


### PR DESCRIPTION
    * Add a getETag method for collections and buckets

    * Update README to document methods and no longer suggest use of last_modified


This fixes #128 . I'm not quite sure how ETag and last modified work here, the server we are using says I cannot pass the last_modified. The docs say it should be treated as an opaque token, which doesn't seem to be true. The linked issue says it is hard to get the ETag, so I'd like to make it simpler. Comments welcome.