### PR TITLE
Fix #471: obfuscate authorization header values in errors

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { delay } from "./utils";
+import { delay, replaceKey } from "./utils";
 import {
   NetworkTimeoutError,
   ServerResponse,
@@ -77,7 +77,12 @@ export default class HTTP {
       if (this.timeout) {
         _timeoutId = setTimeout(() => {
           hasTimedout = true;
-          reject(new NetworkTimeoutError(url, options));
+          reject(
+            new NetworkTimeoutError(
+              url,
+              replaceKey(options, "authorization", "**** (suppressed)")
+            )
+          );
         }, this.timeout);
       }
       function proceedWithHandler(fn) {

--- a/src/http.js
+++ b/src/http.js
@@ -77,12 +77,17 @@ export default class HTTP {
       if (this.timeout) {
         _timeoutId = setTimeout(() => {
           hasTimedout = true;
-          reject(
-            new NetworkTimeoutError(
-              url,
-              replaceKey(options, "authorization", "**** (suppressed)")
-            )
-          );
+          if (options && options.headers) {
+            options = {
+              ...options,
+              headers: replaceKey(
+                options.headers,
+                "authorization",
+                "**** (suppressed)"
+              ),
+            };
+          }
+          reject(new NetworkTimeoutError(url, options));
         }, this.timeout);
       }
       function proceedWithHandler(fn) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,6 +66,15 @@ export function omit(obj, ...keys) {
   }, {});
 }
 
+/**
+ * Replace an object key (case insensitive) value with the specified one.
+ *
+ * @private
+ * @param  {Object} obj
+ * @param  {String} key
+ * @param  {Object} value
+ * @return {Object}
+ */
 export function replaceKey(obj, key, value) {
   return Object.keys(obj).reduce((acc, k) => {
     acc[k] = k.toLowerCase() == key.toLowerCase() ? value : obj[k];

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,6 +66,13 @@ export function omit(obj, ...keys) {
   }, {});
 }
 
+export function replaceKey(obj, key, value) {
+  return Object.keys(obj).reduce((acc, k) => {
+    acc[k] = k.toLowerCase() == key.toLowerCase() ? value : obj[k];
+    return acc;
+  }, {});
+}
+
 /**
  * Always returns a resource data object from the provided argument.
  *

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -130,13 +130,30 @@ describe("HTTP class", () => {
     });
 
     describe("Request timeout", () => {
-      it("should timeout the request", () => {
+      beforeEach(() => {
         sandbox.stub(global, "fetch").returns(
           new Promise(resolve => {
             setTimeout(resolve, 20000);
           })
         );
+      });
+
+      it("should timeout the request", () => {
         return http.request("/").should.be.rejectedWith(NetworkTimeoutError);
+      });
+
+      it("should show request properties in error", () => {
+        return http
+          .request("/", {
+            mode: "cors",
+            headers: {
+              Authorization: "XXX",
+              "User-agent": "mocha-test",
+            },
+          })
+          .should.be.rejectedWith(
+            'Timeout while trying to access / with {"mode":"cors","headers":{"Accept":"application/json","Content-Type":"application/json","Authorization":"XXX","User-agent":"mocha-test"}}'
+          );
       });
     });
 

--- a/test/http_test.js
+++ b/test/http_test.js
@@ -152,7 +152,7 @@ describe("HTTP class", () => {
             },
           })
           .should.be.rejectedWith(
-            'Timeout while trying to access / with {"mode":"cors","headers":{"Accept":"application/json","Content-Type":"application/json","Authorization":"XXX","User-agent":"mocha-test"}}'
+            'Timeout while trying to access / with {"mode":"cors","headers":{"Accept":"application/json","Content-Type":"application/json","Authorization":"**** (suppressed)","User-agent":"mocha-test"}}'
           );
       });
     });


### PR DESCRIPTION
Fix #471

There were many ways to solve this... I could have obfuscated the value in the error constructor, could have removed the options from the logging message, etc. 
Let me know what do you think!