### PR TITLE
Fix ES module import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.7.2",
   "description": "JavaScript HTTP client for the Kinto API.",
   "main": "lib/cjs-es5/index.js",
-  "module": "lib/es/index.js",
+  "module": "lib/esm/index.js",
   "unpkg": "dist/kinto-http.min.js",
   "scripts": {
     "build": "npm run build:es && npm run build:cjs-es5",


### PR DESCRIPTION
The ES module import path is `lib/esm/index.js`, not `lib/es/index.js`.

@leplatrem once this is merged would you mind doing another alpha release on NPM? For now I'm manually changing it inside my `node_modules` folder.