### PR TITLE
Enable down-level iteration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
  - "3.6"
 env:
 - ACTION="run lint"
+- ACTION="run build"
 - ACTION="run dist" # ensures building dist files doesn't break
 - ACTION="run cs-check"
 - SERVER=8.1.2 ACTION=test

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "downlevelIteration": true
   },
   "include": ["./src/"]
 }


### PR DESCRIPTION
`Headers.entries()` returns an `IterableIterator<[string, string]>`. Iterators are an ES6 feature, so the TypeScript compiler has to be explicitly told to convert them to something ES5 environments can understand. This PR enables that option, `downlevelIteration` in `tsconfig`.

Also, to prevent something like this from happening again, `npm run build` has been added to the list of actions for Travis.