### PR TITLE
Replace Greenkeeper badge with Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 kinto-http.js
 =============
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Kinto/kinto-http.js.svg)](https://greenkeeper.io/)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=Kinto/kinto-http.js)](https://dependabot.com)
 
 [![Build Status](https://travis-ci.org/Kinto/kinto-http.js.svg?branch=master)](https://travis-ci.org/Kinto/kinto-http.js)
 


### PR DESCRIPTION
This replaces the non-functional Greenkeeper badge with a Dependabot one since that's what we're using anyway.

Plus it looks nicer than a broken image :)