### PR TITLE
Convert private property access to bracket notation

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -198,18 +198,6 @@ export default class KintoClientBase {
     return 0;
   }
 
-  get safe(): boolean {
-    return this._safe;
-  }
-
-  get isBatch(): boolean {
-    return this._isBatch;
-  }
-
-  get headers(): Record<string, string> {
-    return this._headers;
-  }
-
   /**
    * Registers HTTP events.
    * @private
@@ -246,10 +234,6 @@ export default class KintoClientBase {
       safe: this._getSafe(options),
       retry: this._getRetry(options),
     });
-  }
-
-  set headers(headers: Record<string, string>) {
-    this._headers = headers;
   }
 
   /**

--- a/src/base.ts
+++ b/src/base.ts
@@ -242,7 +242,6 @@ export default class KintoClientBase {
     } = {}
   ) {
     return new Bucket(this, name, {
-      batch: this._isBatch,
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
       retry: this._getRetry(options),

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -17,7 +17,6 @@ export interface BucketOptions {
   safe?: boolean;
   headers?: Record<string, string>;
   retry?: number;
-  batch?: boolean;
 }
 /**
  * Abstract representation of a selected bucket.
@@ -26,7 +25,6 @@ export interface BucketOptions {
 export default class Bucket {
   private client: KintoClientBase;
   public name: string;
-  private _isBatch: boolean;
   private _retry: number;
   private _safe: boolean;
   private _headers: Record<string, string>;
@@ -40,7 +38,6 @@ export default class Bucket {
    * @param  {Object}      [options.headers] The headers object option.
    * @param  {Boolean}     [options.safe]    The safe option.
    * @param  {Number}      [options.retry]   The retry option.
-   * @param  {boolean}     [options.batch]   The batch option.
    */
   constructor(
     client: KintoClientBase,
@@ -56,10 +53,6 @@ export default class Bucket {
      * @type {String}
      */
     this.name = name;
-    /**
-     * @ignore
-     */
-    this._isBatch = !!options.batch;
     /**
      * @ignore
      */
@@ -125,7 +118,6 @@ export default class Bucket {
     } = {}
   ) {
     return new Collection(this.client, this, name, {
-      batch: this._isBatch,
       headers: this._getHeaders(options),
       retry: this._getRetry(options),
       safe: this._getSafe(options),

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -19,7 +19,6 @@ export interface CollectionOptions {
   headers?: Record<string, string>;
   safe?: boolean;
   retry?: number;
-  batch?: boolean;
 }
 
 /**
@@ -30,7 +29,6 @@ export default class Collection {
   public client: KintoClientBase;
   private bucket: Bucket;
   public name: string;
-  private _isBatch: boolean;
   private _retry: number;
   private _safe: boolean;
   private _headers: Record<string, string>;
@@ -71,11 +69,6 @@ export default class Collection {
     /**
      * @ignore
      */
-    this._isBatch = !!options.batch;
-
-    /**
-     * @ignore
-     */
     this._retry = options.retry || 0;
     this._safe = !!options.safe;
     // FIXME: This is kind of ugly; shouldn't the bucket be responsible
@@ -84,22 +77,6 @@ export default class Collection {
       ...this.bucket.headers,
       ...options.headers,
     };
-  }
-
-  get headers(): Record<string, string> {
-    return this._headers;
-  }
-
-  get isBatch(): boolean {
-    return this._isBatch;
-  }
-
-  get retry(): number {
-    return this._retry;
-  }
-
-  get safe(): boolean {
-    return this._safe;
   }
 
   /**

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -77,7 +77,7 @@ describe("KintoClient", () => {
       expect(
         new KintoClient(sampleRemote, {
           headers: { Foo: "Bar" },
-        }).headers
+        })["_headers"]
       ).eql({ Foo: "Bar" });
     });
 
@@ -123,7 +123,7 @@ describe("KintoClient", () => {
 
     it("should accept a safe option", () => {
       const api = new KintoClient(sampleRemote, { safe: true });
-      expect(api.safe).eql(true);
+      expect(api["_safe"]).eql(true);
     });
   });
 
@@ -141,7 +141,7 @@ describe("KintoClient", () => {
       client.setHeaders({
         Authorization: "Baz",
       });
-      expect(client.headers).eql({ Foo: "Bar", Authorization: "Baz" });
+      expect(client["_headers"]).eql({ Foo: "Bar", Authorization: "Baz" });
     });
   });
 
@@ -365,7 +365,7 @@ describe("KintoClient", () => {
         ];
 
         beforeEach(() => {
-          api.headers = { Authorization: "Basic plop" };
+          api["_headers"] = { Authorization: "Basic plop" };
           return api
             .bucket("default")
             .collection("blog")
@@ -1004,7 +1004,7 @@ describe("KintoClient", () => {
       });
 
       it("should support passing custom headers", () => {
-        api.headers = { Foo: "Bar" };
+        api["_headers"] = { Foo: "Bar" };
         api.listPermissions({ headers: { Baz: "Qux" } }).then(() => {
           sinon.assert.calledWithMatch(executeSpy, {
             path: "/permissions",
@@ -1073,7 +1073,7 @@ describe("KintoClient", () => {
     });
 
     it("should support passing custom headers", () => {
-      api.headers = { Foo: "Bar" };
+      api["_headers"] = { Foo: "Bar" };
       api.listBuckets({ headers: { Baz: "Qux" } });
 
       sinon.assert.calledWithMatch(
@@ -1144,7 +1144,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.headers = { Foo: "Bar" };
+      api["_headers"] = { Foo: "Bar" };
 
       api.createBucket("foo", { headers: { Baz: "Qux" } });
 
@@ -1193,7 +1193,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.headers = { Foo: "Bar" };
+      api["_headers"] = { Foo: "Bar" };
 
       api.deleteBucket("plop", { headers: { Baz: "Qux" } });
 
@@ -1239,7 +1239,7 @@ describe("KintoClient", () => {
     });
 
     it("should extend request headers with optional ones", () => {
-      api.headers = { Foo: "Bar" };
+      api["_headers"] = { Foo: "Bar" };
 
       return api.deleteBuckets({ headers: { Baz: "Qux" } }).then(_ => {
         sinon.assert.calledWithMatch(deleteRequestStub, "/buckets", {

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -186,7 +186,6 @@ describe("KintoClient", () => {
       expect(bucket)
         .property("_headers")
         .eql(options.headers);
-      expect(bucket).property("_isBatch", options.batch);
     });
   });
 

--- a/test/bucket_test.ts
+++ b/test/bucket_test.ts
@@ -145,10 +145,9 @@ describe("Bucket", () => {
         headers: { Foo: "Bar" },
         safe: true,
       }).collection("posts", { headers: { Baz: "Qux" }, safe: false });
-      expect(collection.headers).eql({ Foo: "Bar", Baz: "Qux" });
-      expect(collection.retry).eql(0);
-      expect(collection.safe).eql(false);
-      expect(collection.isBatch).eql(false);
+      expect(collection["_headers"]).eql({ Foo: "Bar", Baz: "Qux" });
+      expect(collection["_retry"]).eql(0);
+      expect(collection["_safe"]).eql(false);
     });
   });
 


### PR DESCRIPTION
After my [previous PR](https://github.com/Kinto/kinto-http.js/pull/503), I did a bit of research to see if there was a better way to access private properties during unit tests. Lo and behold, there is! Apparently, there's an [explicit escape hatch](https://github.com/microsoft/TypeScript/issues/19335) specifically for this purpose.

This PR removes the added getters, replacing them with bracket notation in tests.

While removing the getters, the TypeScript compiler discovered that the `_isBatch` property on `Bucket` and `Collection` is never read; in fact, it's also not read in `kinto.js`. As such, I've removed the property from `Bucket` and `Collection`. The property still exists on `KintoClientBase`, so in theory if someone really wanted to know the value they could do something like `batch["client"]["_isBatch"]`.