### PR TITLE
Add explicit function return types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,13 @@
     "no-console": 0,
     "no-var": 2,
     "prefer-const": 1,
-    "semi": [2, "always"]
+    "semi": [2, "always"],
+    "@typescript-eslint/explicit-function-return-type": [
+      2,
+      {
+        "allowExpressions": true
+      }
+    ]
   },
   "env": {
     "es6": true,
@@ -19,5 +25,6 @@
     "node": true
   },
   "extends": ["prettier/@typescript-eslint"],
-  "root": true
+  "root": true,
+  "plugins": ["@typescript-eslint/eslint-plugin"]
 }

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -50,7 +50,7 @@ export interface KintoResponse {
 export function aggregate(
   responses: KintoResponse[] = [],
   requests: KintoRequest[] = []
-) {
+): AggregateResponse {
   if (responses.length !== requests.length) {
     throw new Error("Responses length should match requests one.");
   }

--- a/src/http.ts
+++ b/src/http.ts
@@ -33,7 +33,7 @@ export default class HTTP {
    *
    * @type {Object}
    */
-  static get DEFAULT_REQUEST_HEADERS() {
+  static get DEFAULT_REQUEST_HEADERS(): Record<string, string> {
     return {
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -106,7 +106,7 @@ export default class HTTP {
           reject(new NetworkTimeoutError(url, options));
         }, this.timeout);
       }
-      function proceedWithHandler(fn: (arg: any) => void) {
+      function proceedWithHandler(fn: (arg: any) => void): (arg: any) => void {
         return (arg: any) => {
           if (!hasTimedout) {
             if (_timeoutId) {
@@ -151,7 +151,7 @@ export default class HTTP {
     retryAfter: number,
     request: RequestInit,
     options: RequestOptions
-  ) {
+  ): Promise<HttpResponse<T>> {
     await delay(retryAfter);
     return this.request<T>(url, request, {
       ...options,
@@ -210,7 +210,7 @@ export default class HTTP {
     }
   }
 
-  _checkForDeprecationHeader(headers: Headers) {
+  _checkForDeprecationHeader(headers: Headers): void {
     const alertHeader = headers.get("Alert");
     if (!alertHeader) {
       return;
@@ -226,7 +226,7 @@ export default class HTTP {
     this.events.emit("deprecated", alert);
   }
 
-  _checkForBackoffHeader(headers: Headers) {
+  _checkForBackoffHeader(headers: Headers): void {
     let backoffMs;
     const backoffHeader = headers.get("Backoff");
     const backoffSeconds = backoffHeader ? parseInt(backoffHeader, 10) : 0;
@@ -238,7 +238,7 @@ export default class HTTP {
     this.events.emit("backoff", backoffMs);
   }
 
-  _checkForRetryAfterHeader(headers: Headers) {
+  _checkForRetryAfterHeader(headers: Headers): number | undefined {
     const retryAfter = headers.get("Retry-After");
     if (!retryAfter) {
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,20 +24,20 @@ export type Permission =
   | "group:create"
   | "record:create";
 
-interface User {
+export interface User {
   id: string;
   principals: string[];
   bucket: string;
 }
 
-interface ServerCapability {
+export interface ServerCapability {
   description: string;
   url: string;
   version?: string;
   [key: string]: unknown;
 }
 
-interface ServerSettings {
+export interface ServerSettings {
   readonly: boolean;
   batch_max_requests: number;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@
  * @param  {Number} n
  * @return {Array}
  */
-export function partition<T>(array: T[], n: number) {
+export function partition<T>(array: T[], n: number): T[][] {
   if (n <= 0) {
     return [array];
   }
@@ -25,7 +25,7 @@ export function partition<T>(array: T[], n: number) {
  *
  * @return Promise<void>
  */
-export function delay(ms: number) {
+export function delay(ms: number): Promise<unknown> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
@@ -85,8 +85,9 @@ export function checkVersion(
   version: string,
   minVersion: string,
   maxVersion: string
-) {
-  const extract = (str: string) => str.split(".").map(x => parseInt(x, 10));
+): void {
+  const extract = (str: string): number[] =>
+    str.split(".").map(x => parseInt(x, 10));
   const [verMajor, verMinor] = extract(version);
   const [minMajor, minMinor] = extract(minVersion);
   const [maxMajor, maxMinor] = extract(maxVersion);
@@ -103,6 +104,15 @@ export function checkVersion(
   }
 }
 
+type DecoratorReturn = (
+  target: any,
+  key: string,
+  descriptor: TypedPropertyDescriptor<(...args: any[]) => any>
+) => {
+  configurable: boolean;
+  get(): (...args: any) => Promise<any>;
+};
+
 /**
  * Generates a decorator function ensuring a version check is performed against
  * the provided requirements before executing it.
@@ -111,7 +121,7 @@ export function checkVersion(
  * @param  {String} max The required max version (inclusive).
  * @return {Function}
  */
-export function support(min: string, max: string) {
+export function support(min: string, max: string): DecoratorReturn {
   return function(
     // @ts-ignore
     target: any,
@@ -148,7 +158,7 @@ export function support(min: string, max: string) {
  * @param  {Array<String>} capabilities The required capabilities.
  * @return {Function}
  */
-export function capable(capabilities: string[]) {
+export function capable(capabilities: string[]): DecoratorReturn {
   return function(
     // @ts-ignore
     target: any,
@@ -193,7 +203,7 @@ export function capable(capabilities: string[]) {
  * @param  {String} message The error message to throw.
  * @return {Function}
  */
-export function nobatch(message: string) {
+export function nobatch(message: string): DecoratorReturn {
   return function(
     // @ts-ignore
     target: any,
@@ -263,7 +273,12 @@ export function parseDataURL(dataURL: string): TypedDataURL {
  * @param  {String} dataURL The data url.
  * @return {Object}
  */
-export function extractFileInfo(dataURL: string) {
+export function extractFileInfo(
+  dataURL: string
+): {
+  blob: Blob;
+  name: string;
+} {
   const { name, type, base64 } = parseDataURL(dataURL);
   const binary = atob(base64);
   const array = [];
@@ -294,7 +309,7 @@ export function createFormData(
   dataURL: string,
   body: { [key: string]: any },
   options: { filename?: string } = {}
-) {
+): FormData {
   const { filename = "untitled" } = options;
   const { blob, name } = extractFileInfo(dataURL);
   const formData = new FormData();
@@ -311,7 +326,11 @@ export function createFormData(
  * Clones an object with all its undefined keys removed.
  * @private
  */
-export function cleanUndefinedProperties(obj: { [key: string]: any }) {
+export function cleanUndefinedProperties(obj: {
+  [key: string]: any;
+}): {
+  [key: string]: any;
+} {
   const result: { [key: string]: any } = {};
   for (const key in obj) {
     if (typeof obj[key] !== "undefined") {
@@ -332,7 +351,7 @@ export function cleanUndefinedProperties(obj: { [key: string]: any }) {
 export function addEndpointOptions(
   path: string,
   options: { fields?: string[]; query?: { [key: string]: string } } = {}
-) {
+): string {
   const query: { [key: string]: any } = { ...options.query };
   if (options.fields) {
     query._fields = options.fields;
@@ -347,7 +366,11 @@ export function addEndpointOptions(
 /**
  * Replace authorization header with an obscured version
  */
-export function obscureAuthorizationHeader(headers: HeadersInit) {
+export function obscureAuthorizationHeader(
+  headers: HeadersInit
+): {
+  [key: string]: string;
+} {
   const h = new Headers(headers);
   if (h.has("authorization")) {
     h.set("authorization", "**** (suppressed)");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,11 +58,9 @@ export function toDataBody<T extends Entity>(resource: T | string): Entity {
  * @return {String}
  */
 export function qsify(obj: { [key: string]: any }): string {
-  const encode = (v: any) =>
+  const encode = (v: any): string =>
     encodeURIComponent(typeof v === "boolean" ? String(v) : v);
-  const stripUndefined = (o: { [key: string]: any }) =>
-    JSON.parse(JSON.stringify(o));
-  const stripped = stripUndefined(obj);
+  const stripped = cleanUndefinedProperties(obj);
   return Object.keys(stripped)
     .map(k => {
       const ks = encode(k) + "=";

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,8 @@
 {
-    "env": {
-        "mocha": true
-    }
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
 }


### PR DESCRIPTION
This PR adds explicit return types to class methods and functions. Since it's just adding the types that the TypeScript compiler is already inferring, this doesn't actually change any functionality.

It also activates an eslint rule requiring all functions and class methods to explicitly declare their return types.

The primary motivator for this is to make it apparent to the developer what the return type of the function is, and to ensure that they don't accidentally modify the return type without realizing it. It also points out where we're being fast and loose with the typings, resulting in return types that look like `Promise<unknown>` and `Promise<KintoResponse<unknown>>`. These return types are still type-safe since trying to access properties on `unknown` will throw a compiler error, but we should definitely clean these up with the actual response type.