### PR TITLE
Add response types for API methods

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -852,16 +852,16 @@ export default class KintoClientBase {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
     const path = endpoint.bucket();
-    return this.execute(
+    return this.execute<KintoResponse<{ deleted: boolean }>>(
       requests.deleteRequest(path, {
         last_modified: options.last_modified,
         headers: this._getHeaders(options),
         safe: this._getSafe(options),
       }),
       { retry: this._getRetry(options) }
-    );
+    ) as Promise<KintoResponse<{ deleted: boolean }>>;
   }
 
   @capable(["accounts"])

--- a/src/base.ts
+++ b/src/base.ts
@@ -865,13 +865,16 @@ export default class KintoClientBase {
   }
 
   @capable(["accounts"])
-  async createAccount(username: string, password: string): Promise<unknown> {
-    return this.execute(
+  async createAccount(
+    username: string,
+    password: string
+  ): Promise<KintoResponse<{ password: string }>> {
+    return this.execute<KintoResponse<{ password: string }>>(
       requests.createRequest(
         `/accounts/${username}`,
         { data: { password } },
         { method: "PUT" }
       )
-    );
+    ) as Promise<KintoResponse<{ password: string }>>;
   }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -817,21 +817,21 @@ export default class KintoClientBase {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
     const bucketObj = toDataBody(bucket);
     if (!bucketObj.id) {
       throw new Error("A bucket id is required.");
     }
     const path = endpoint.bucket(bucketObj.id);
     const { last_modified } = { ...bucketObj, ...options };
-    return this.execute(
+    return this.execute<KintoResponse<{ deleted: boolean }>>(
       requests.deleteRequest(path, {
         last_modified,
         headers: this._getHeaders(options),
         safe: this._getSafe(options),
       }),
       { retry: this._getRetry(options) }
-    );
+    ) as Promise<KintoResponse<{ deleted: boolean }>>;
   }
 
   /**

--- a/src/base.ts
+++ b/src/base.ts
@@ -767,25 +767,26 @@ export default class KintoClientBase {
    *     when faced with transient errors.
    * @return {Promise<Object, Error>}
    */
-  async createBucket(
+  async createBucket<T extends MappableObject>(
     id: string | null,
     options: {
-      data?: MappableObject & { id?: string };
+      data?: T & { id?: string };
       permissions?: Partial<Record<Permission, string[]>>;
       safe?: boolean;
       headers?: Record<string, string>;
       retry?: number;
     } = {}
-  ): Promise<KintoResponse<unknown> | HttpResponse<KintoResponse<unknown>>> {
-    const { data = {}, permissions } = options;
-    if (id != null) {
-      data.id = id;
-    }
-    const path = data.id ? endpoint.bucket(data.id) : endpoint.bucket();
-    return this.execute<KintoResponse>(
+  ): Promise<
+    | KintoResponse<T & { id: string }>
+    | HttpResponse<KintoResponse<T & { id: string }>>
+  > {
+    const { data, permissions } = options;
+    const _data = { ...data, id: id ? id : undefined };
+    const path = _data.id ? endpoint.bucket(_data.id) : endpoint.bucket();
+    return this.execute<KintoResponse<T & { id: string }>>(
       requests.createRequest(
         path,
-        { data, permissions },
+        { data: _data, permissions },
         {
           headers: this._getHeaders(options),
           safe: this._getSafe(options),

--- a/src/base.ts
+++ b/src/base.ts
@@ -684,19 +684,21 @@ export default class KintoClientBase {
       return processNextPage(nextPage);
     };
 
-    return handleResponse((await this.execute(
-      // N.B.: This doesn't use _getHeaders, because all calls to
-      // `paginatedList` are assumed to come from calls that already
-      // have headers merged at e.g. the bucket or collection level.
-      {
-        headers: options.headers ? options.headers : {},
-        path: path + "?" + querystring,
-      },
-      // N.B. This doesn't use _getRetry, because all calls to
-      // `paginatedList` are assumed to come from calls that already
-      // used `_getRetry` at e.g. the bucket or collection level.
-      { raw: true, retry: options.retry || 0 }
-    )) as HttpResponse<DataResponse<T[]>>);
+    return handleResponse(
+      (await this.execute(
+        // N.B.: This doesn't use _getHeaders, because all calls to
+        // `paginatedList` are assumed to come from calls that already
+        // have headers merged at e.g. the bucket or collection level.
+        {
+          headers: options.headers ? options.headers : {},
+          path: path + "?" + querystring,
+        },
+        // N.B. This doesn't use _getRetry, because all calls to
+        // `paginatedList` are assumed to come from calls that already
+        // used `_getRetry` at e.g. the bucket or collection level.
+        { raw: true, retry: options.retry || 0 }
+      )) as HttpResponse<DataResponse<T[]>>
+    );
   }
 
   /**
@@ -776,14 +778,11 @@ export default class KintoClientBase {
       headers?: Record<string, string>;
       retry?: number;
     } = {}
-  ): Promise<
-    | KintoResponse<T & { id: string }>
-    | HttpResponse<KintoResponse<T & { id: string }>>
-  > {
+  ): Promise<KintoResponse<T>> {
     const { data, permissions } = options;
     const _data = { ...data, id: id ? id : undefined };
     const path = _data.id ? endpoint.bucket(_data.id) : endpoint.bucket();
-    return this.execute<KintoResponse<T & { id: string }>>(
+    return this.execute<KintoResponse<T>>(
       requests.createRequest(
         path,
         { data: _data, permissions },
@@ -793,7 +792,7 @@ export default class KintoClientBase {
         }
       ),
       { retry: this._getRetry(options) }
-    );
+    ) as Promise<KintoResponse<T>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -522,10 +522,10 @@ export default class Bucket {
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  async updateGroup(
+  async updateGroup<T extends MappableObject>(
     group: KintoIdObject,
     options: {
-      data?: { last_modified?: number; [key: string]: any };
+      data?: T & { members?: string[] };
       permissions?: { [key in Permission]?: string[] };
       safe?: boolean;
       headers?: Record<string, string>;
@@ -533,7 +533,7 @@ export default class Bucket {
       last_modified?: number;
       patch?: boolean;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<T & { members: string[] }>> {
     if (!isObject(group)) {
       throw new Error("A group object is required.");
     }
@@ -557,7 +557,12 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<KintoResponse<T & { members: string[] }>>(
+      request,
+      {
+        retry: this._getRetry(options),
+      }
+    ) as Promise<KintoResponse<T & { members: string[] }>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -645,7 +645,7 @@ export default class Bucket {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -660,9 +660,9 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{}>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -12,6 +12,7 @@ import {
   KintoObject,
   Group,
   OperationResponse,
+  MappableObject,
 } from "./types";
 import { HttpResponse } from "./http";
 import { AggregateResponse } from "./batch";
@@ -231,8 +232,8 @@ export default class Bucket {
    * @param  {Number}  [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  async setData(
-    data: { last_modified?: number; [key: string]: any },
+  async setData<T extends MappableObject>(
+    data: T & { last_modified?: number },
     options: {
       headers?: Record<string, string>;
       safe?: boolean;
@@ -241,7 +242,7 @@ export default class Bucket {
       last_modified?: number;
       permissions?: { [key in Permission]?: string[] };
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<T>> {
     if (!isObject(data)) {
       throw new Error("A bucket object is required.");
     }
@@ -268,9 +269,9 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<T>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<T>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -585,7 +585,7 @@ export default class Bucket {
       safe?: boolean;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
     const groupObj = toDataBody(group);
     const { id } = groupObj;
     const { last_modified } = { ...groupObj, ...options };
@@ -595,7 +595,9 @@ export default class Bucket {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -153,7 +153,7 @@ export default class Bucket {
     const { headers } = (await this.client.execute(request, {
       raw: true,
       retry: this._getRetry(options),
-    })) as HttpResponse<unknown>;
+    })) as HttpResponse<{}>;
     return headers.get("ETag");
   }
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -685,7 +685,7 @@ export default class Bucket {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -701,9 +701,9 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{}>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**
@@ -726,7 +726,7 @@ export default class Bucket {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -742,9 +742,9 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{}>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -346,7 +346,7 @@ export default class Bucket {
       permissions?: { [key in Permission]?: string[] };
       data?: any;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{}>> {
     const { permissions, data = {} } = options;
     data.id = id;
     const path = endpoint.collection(this.name, id);
@@ -358,9 +358,9 @@ export default class Bucket {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{}>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -181,7 +181,7 @@ export default class Bucket {
     const { headers } = (await this.client.execute(request, {
       raw: true,
       retry: this._getRetry(options),
-    })) as HttpResponse<unknown>;
+    })) as HttpResponse<{}>;
     return headers.get("ETag");
   }
 

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -383,7 +383,7 @@ export default class Bucket {
       safe?: boolean;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
     const collectionObj = toDataBody(collection);
     if (!collectionObj.id) {
       throw new Error("A collection id is required.");
@@ -396,7 +396,9 @@ export default class Bucket {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -585,7 +585,7 @@ export default class Collection {
       safe?: boolean;
       last_modified?: number;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{ deleted: boolean }>> {
     const recordObj = toDataBody(record);
     if (!recordObj.id) {
       throw new Error("A record id is required.");
@@ -598,9 +598,9 @@ export default class Collection {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{ deleted: boolean }>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{ deleted: boolean }>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -530,8 +530,8 @@ export default class Collection {
    * @param  {Object}  [options.permissions]   The permissions option.
    * @return {Promise<Object, Error>}
    */
-  async updateRecord(
-    record: KintoIdObject,
+  async updateRecord<T>(
+    record: T & { id: string },
     options: {
       headers?: Record<string, string>;
       retry?: number;
@@ -540,7 +540,7 @@ export default class Collection {
       permissions?: { [key in Permission]?: string[] };
       patch?: boolean;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<T>> {
     if (!isObject(record)) {
       throw new Error("A record object is required.");
     }
@@ -560,9 +560,9 @@ export default class Collection {
         patch: !!options.patch,
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<T>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<T>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -329,7 +329,7 @@ export default class Collection {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -345,7 +345,9 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**
@@ -368,7 +370,7 @@ export default class Collection {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -384,7 +386,9 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<KintoResponse<{}>>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -166,7 +166,7 @@ export default class Collection {
     const { headers } = (await this.client.execute(request, {
       raw: true,
       retry: this._getRetry(options),
-    })) as HttpResponse<unknown>;
+    })) as HttpResponse<{}>;
     return headers.get("ETag");
   }
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -290,7 +290,7 @@ export default class Collection {
       retry?: number;
       last_modified?: number;
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<{}>> {
     if (!isObject(permissions)) {
       throw new Error("A permissions object is required.");
     }
@@ -304,9 +304,9 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<{}>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<{}>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -403,15 +403,15 @@ export default class Collection {
    * @param  {Object}  [options.permissions] The permissions option.
    * @return {Promise<Object, Error>}
    */
-  async createRecord(
-    record: { id?: string; [key: string]: any },
+  async createRecord<T extends MappableObject>(
+    record: T & { id?: string },
     options: {
       headers?: Record<string, string>;
       retry?: number;
       safe?: boolean;
       permissions?: { [key in Permission]?: string[] };
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<T>> {
     const { permissions } = options;
     const path = endpoint.record(this.bucket.name, this.name, record.id);
     const request = requests.createRequest(
@@ -422,9 +422,9 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<T>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<T>>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -504,7 +504,7 @@ export default class Collection {
       safe?: boolean;
       last_modified?: number;
     } = {}
-  ): Promise<unknown> {
+  ): Promise<{}> {
     const { last_modified } = options;
     const path = endpoint.attachment(this.bucket.name, this.name, recordId);
     const request = requests.deleteRequest(path, {
@@ -512,7 +512,9 @@ export default class Collection {
       headers: this._getHeaders(options),
       safe: this._getSafe(options),
     });
-    return this.client.execute(request, { retry: this._getRetry(options) });
+    return this.client.execute<{}>(request, {
+      retry: this._getRetry(options),
+    }) as Promise<{}>;
   }
 
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -15,6 +15,7 @@ import {
   Attachment,
   HistoryEntry,
   OperationResponse,
+  MappableObject,
 } from "./types";
 import { HttpResponse } from "./http";
 import { AggregateResponse } from "./batch";
@@ -213,8 +214,8 @@ export default class Collection {
    * @param  {Number}   [options.last_modified] The last_modified option.
    * @return {Promise<Object, Error>}
    */
-  async setData(
-    data: { last_modified?: number; [key: string]: any },
+  async setData<T extends MappableObject>(
+    data: T & { last_modified?: number },
     options: {
       headers?: Record<string, string>;
       safe?: boolean;
@@ -223,7 +224,7 @@ export default class Collection {
       last_modified?: number;
       permissions?: { [key in Permission]?: string[] };
     } = {}
-  ): Promise<KintoResponse<unknown>> {
+  ): Promise<KintoResponse<T>> {
     if (!isObject(data)) {
       throw new Error("A collection object is required.");
     }
@@ -241,9 +242,9 @@ export default class Collection {
         safe: this._getSafe(options),
       }
     );
-    return this.client.execute<KintoResponse>(request, {
+    return this.client.execute<KintoResponse<T>>(request, {
       retry: this._getRetry(options),
-    }) as Promise<KintoResponse<unknown>>;
+    }) as Promise<KintoResponse<T>>;
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export function partition<T>(array: T[], n: number): T[][] {
  *
  * @return Promise<void>
  */
-export function delay(ms: number): Promise<unknown> {
+export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 


### PR DESCRIPTION
This PR updates the methods that interact with the API to return the correct data type. This ensures that callers are able to access the expected properties on these methods.

Fixes #517