### PR TITLE
Add Windows CI GitHub Workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Windows Integration
+jobs:
+  chore:
+    name: Testing on Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Print environment
+        run: |
+          node --version
+          npm --version
+          python --version
+          pip --version
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Python dependencies
+        run: pip install kinto kinto-attachment
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This PR adds a GitHub Action that runs the tests on Windows. It also adds a `.gitattributes` file forcing git to always use LF line endings regardless of Git's settings.

Fixes #519.