### PR TITLE
Replace EventEmitter with interface and make it optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3652,6 +3652,12 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mitt": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
+      "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
+      "dev": true
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "http-server": "^0.12.0",
     "jsdom": "^16.0.0",
     "kinto-node-test-server": "^1.0.0",
+    "mitt": "^1.2.0",
     "mocha": "^7.0.0",
     "node-fetch": "^2.6.0",
     "nyc": "^15.0.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -39,7 +39,7 @@ export const SUPPORTED_PROTOCOL_VERSION = "v1";
 
 export interface KintoClientOptions {
   safe?: boolean;
-  events: EventEmitter;
+  events?: EventEmitter;
   headers?: Record<string, string>;
   retry?: number;
   bucket?: string;
@@ -88,7 +88,7 @@ export default class KintoClientBase {
   private _safe: boolean;
   private _headers: Record<string, string>;
   public serverInfo: HelloResponse | null;
-  public events: EventEmitter;
+  public events?: EventEmitter;
   public http: HTTP;
   private _remote!: string;
   private _version!: string;
@@ -205,7 +205,7 @@ export default class KintoClientBase {
    */
   private _registerHTTPEvents(): void {
     // Prevent registering event from a batch client instance
-    if (!this._isBatch) {
+    if (!this._isBatch && this.events) {
       this.events.on("backoff", backoffMs => {
         this._backoffReleaseTime = backoffMs;
       });

--- a/src/base.ts
+++ b/src/base.ts
@@ -12,7 +12,6 @@ import * as requests from "./requests";
 import { aggregate, AggregateResponse } from "./batch";
 import Bucket from "./bucket";
 import { capable } from "./utils";
-import { EventEmitter } from "events";
 import {
   HelloResponse,
   KintoRequest,
@@ -28,6 +27,7 @@ import {
   ServerSettings,
   ServerCapability,
   User,
+  Emitter,
 } from "./types";
 import Collection from "./collection";
 
@@ -39,7 +39,7 @@ export const SUPPORTED_PROTOCOL_VERSION = "v1";
 
 export interface KintoClientOptions {
   safe?: boolean;
-  events?: EventEmitter;
+  events?: Emitter;
   headers?: Record<string, string>;
   retry?: number;
   bucket?: string;
@@ -88,7 +88,7 @@ export default class KintoClientBase {
   private _safe: boolean;
   private _headers: Record<string, string>;
   public serverInfo: HelloResponse | null;
-  public events?: EventEmitter;
+  public events?: Emitter;
   public http: HTTP;
   private _remote!: string;
   private _version!: string;

--- a/src/http.ts
+++ b/src/http.ts
@@ -5,6 +5,7 @@ import {
   UnparseableResponseError,
   ServerResponseObject,
 } from "./errors";
+import { Emitter } from "./types";
 
 interface HttpOptions {
   timeout?: number | null;
@@ -47,7 +48,7 @@ export default class HTTP {
     return { timeout: null, requestMode: "cors" };
   }
 
-  public events?: NodeJS.EventEmitter;
+  public events?: Emitter;
   public requestMode: RequestMode;
   public timeout: number;
 
@@ -59,7 +60,7 @@ export default class HTTP {
    * @param {Number}       [options.timeout=null]       The request timeout in ms, if any (default: `null`).
    * @param {String}       [options.requestMode="cors"] The HTTP request mode (default: `"cors"`).
    */
-  constructor(events?: NodeJS.EventEmitter, options: HttpOptions = {}) {
+  constructor(events?: Emitter, options: HttpOptions = {}) {
     // public properties
     /**
      * The event emitter instance.

--- a/src/http.ts
+++ b/src/http.ts
@@ -47,7 +47,7 @@ export default class HTTP {
     return { timeout: null, requestMode: "cors" };
   }
 
-  public events: NodeJS.EventEmitter;
+  public events?: NodeJS.EventEmitter;
   public requestMode: RequestMode;
   public timeout: number;
 
@@ -59,15 +59,12 @@ export default class HTTP {
    * @param {Number}       [options.timeout=null]       The request timeout in ms, if any (default: `null`).
    * @param {String}       [options.requestMode="cors"] The HTTP request mode (default: `"cors"`).
    */
-  constructor(events: NodeJS.EventEmitter, options: HttpOptions = {}) {
+  constructor(events?: NodeJS.EventEmitter, options: HttpOptions = {}) {
     // public properties
     /**
      * The event emitter instance.
      * @type {EventEmitter}
      */
-    if (!events) {
-      throw new Error("No events handler provided");
-    }
     this.events = events;
 
     /**
@@ -221,7 +218,9 @@ export default class HTTP {
       return;
     }
     console.warn(alert.message, alert.url);
-    this.events.emit("deprecated", alert);
+    if (this.events) {
+      this.events.emit("deprecated", alert);
+    }
   }
 
   _checkForBackoffHeader(headers: Headers): void {
@@ -233,7 +232,9 @@ export default class HTTP {
     } else {
       backoffMs = 0;
     }
-    this.events.emit("backoff", backoffMs);
+    if (this.events) {
+      this.events.emit("backoff", backoffMs);
+    }
   }
 
   _checkForRetryAfterHeader(headers: Headers): number | undefined {
@@ -243,7 +244,9 @@ export default class HTTP {
     }
     const delay = parseInt(retryAfter, 10) * 1000;
     const tryAgainAfter = new Date().getTime() + delay;
-    this.events.emit("retry-after", tryAgainAfter);
+    if (this.events) {
+      this.events.emit("retry-after", tryAgainAfter);
+    }
     return delay;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from "events";
-
 import KintoClientBase, { KintoClientOptions } from "./base";
 import { AggregateResponse } from "./batch";
 import Collection from "./collection";
@@ -7,7 +5,7 @@ import { KintoObject, KintoIdObject, KintoResponse, Permission } from "./types";
 
 export default class KintoClient extends KintoClientBase {
   constructor(remote: string, options: Partial<KintoClientOptions> = {}) {
-    const events = options.events || new EventEmitter();
+    const events = options.events;
 
     super(remote, Object.assign({ events }, options));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,3 +109,9 @@ export interface Attachment {
 export interface Group extends KintoObject {
   members: string[];
 }
+
+export interface Emitter {
+  emit(type: string, event?: any): void;
+  on(type: string, handler: (event?: any) => void): void;
+  off(type: string, handler: (event?: any) => void): void;
+}

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -106,10 +106,8 @@ describe("KintoClient", () => {
       ).eql(timeout);
     });
 
-    it("should create an event emitter if none is provided", () => {
-      expect(new KintoClient(sampleRemote).events).to.be.an.instanceOf(
-        EventEmitter
-      );
+    it("should not create an event emitter if none is provided", () => {
+      expect(new KintoClient(sampleRemote).events).to.be.undefined;
     });
 
     it("should expose provided event emitter as a property", () => {

--- a/test/http_test.ts
+++ b/test/http_test.ts
@@ -14,428 +14,459 @@ chai.config.includeStack = true;
 
 /** @test {HTTP} */
 describe("HTTP class", () => {
-  let sandbox: sinon.SinonSandbox, events: EventEmitter, http: HTTP;
+  function runSuite(label: string, emitter?: typeof EventEmitter) {
+    describe(label, () => {
+      let sandbox: sinon.SinonSandbox,
+        events: EventEmitter | undefined,
+        http: HTTP;
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    events = new EventEmitter();
-    http = new HTTP(events, { timeout: 100 });
-  });
-
-  afterEach(() => sandbox.restore());
-
-  /** @test {HTTP#constructor} */
-  describe("#constructor", () => {
-    it("should expose a passed events instance", () => {
-      const events = new EventEmitter();
-      const http = new HTTP(events);
-      expect(http.events).to.eql(events);
-    });
-
-    it("should accept a requestMode option", () => {
-      expect(
-        new HTTP(events, {
-          requestMode: "no-cors",
-        }).requestMode
-      ).eql("no-cors");
-    });
-
-    it("should complain if an events handler is not provided", () => {
-      expect(() => {
-        new (HTTP as any)();
-      }).to.Throw(Error, /No events handler provided/);
-    });
-  });
-
-  /** @test {HTTP#request} */
-  describe("#request()", () => {
-    describe("Request headers", () => {
-      let fetchStub: sinon.SinonStub;
       beforeEach(() => {
-        fetchStub = sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, {}, {}));
+        sandbox = sinon.createSandbox();
+        events = emitter ? new emitter() : undefined;
+        http = new HTTP(events, { timeout: 100 });
       });
 
-      it("should set default headers", () => {
-        http.request("/");
+      afterEach(() => sandbox.restore());
 
-        expect(fetchStub.firstCall.args[1].headers).eql(
-          HTTP.DEFAULT_REQUEST_HEADERS
-        );
-      });
-
-      it("should merge custom headers with default ones", () => {
-        http.request("/", { headers: { Foo: "Bar" } });
-
-        expect(fetchStub.firstCall.args[1].headers.Foo).eql("Bar");
-      });
-
-      it("should drop custom content-type header for multipart body", () => {
-        http.request("/", {
-          headers: { "Content-Type": "application/foo" },
-          body: new FormData(),
+      /** @test {HTTP#constructor} */
+      describe("#constructor", () => {
+        it("should expose a passed events instance", () => {
+          const events = new EventEmitter();
+          const http = new HTTP(events);
+          expect(http.events).to.eql(events);
         });
 
-        expect(fetchStub.firstCall.args[1].headers["Content-Type"]).to.be
-          .undefined;
-      });
-    });
+        it("should accept a requestMode option", () => {
+          expect(
+            new HTTP(events, {
+              requestMode: "no-cors",
+            }).requestMode
+          ).eql("no-cors");
+        });
 
-    describe("Request CORS mode", () => {
-      let fetchStub: sinon.SinonStub;
-      beforeEach(() => {
-        fetchStub = sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, {}, {}));
-      });
-
-      it("should use default CORS mode", () => {
-        new HTTP(events).request("/");
-
-        expect(fetchStub.firstCall.args[1].mode).eql("cors");
+        it("should not complain if an events handler is not provided", () => {
+          expect(() => {
+            new HTTP();
+          }).not.to.Throw(Error, /No events handler provided/);
+        });
       });
 
-      it("should use configured custom CORS mode", () => {
-        new HTTP(events, { requestMode: "no-cors" }).request("/");
+      /** @test {HTTP#request} */
+      describe("#request()", () => {
+        describe("Request headers", () => {
+          let fetchStub: sinon.SinonStub;
+          beforeEach(() => {
+            fetchStub = sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, {}, {}));
+          });
 
-        expect(fetchStub.firstCall.args[1].mode).eql("no-cors");
-      });
-    });
+          it("should set default headers", () => {
+            http.request("/");
 
-    describe("Succesful request", () => {
-      beforeEach(() => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, { a: 1 }, { b: 2 }));
-      });
+            expect(fetchStub.firstCall.args[1].headers).eql(
+              HTTP.DEFAULT_REQUEST_HEADERS
+            );
+          });
 
-      it("should resolve with HTTP status", async () => {
-        const { status } = await http.request("/");
-        status.should.equal(200);
-      });
+          it("should merge custom headers with default ones", () => {
+            http.request("/", { headers: { Foo: "Bar" } });
 
-      it("should resolve with JSON body", async () => {
-        const { json } = await http.request("/");
-        (json as { a: number }).should.deep.equal({ a: 1 });
-      });
+            expect(fetchStub.firstCall.args[1].headers.Foo).eql("Bar");
+          });
 
-      it("should resolve with headers", async () => {
-        const { headers } = await http.request("/");
-        headers.get("b")!.should.equal(2);
-      });
-    });
-
-    describe("Request timeout", () => {
-      beforeEach(() => {
-        sandbox.stub(global as any, "fetch").returns(
-          new Promise(resolve => {
-            setTimeout(resolve, 20000);
-          })
-        );
-      });
-
-      it("should timeout the request", async () => {
-        await expectAsyncError(
-          () => http.request("/"),
-          undefined,
-          NetworkTimeoutError
-        );
-      });
-
-      it("should show request properties in error", async () => {
-        await expectAsyncError(
-          () =>
+          it("should drop custom content-type header for multipart body", () => {
             http.request("/", {
-              mode: "cors",
+              headers: { "Content-Type": "application/foo" },
+              body: new FormData(),
+            });
+
+            expect(fetchStub.firstCall.args[1].headers["Content-Type"]).to.be
+              .undefined;
+          });
+        });
+
+        describe("Request CORS mode", () => {
+          let fetchStub: sinon.SinonStub;
+          beforeEach(() => {
+            fetchStub = sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, {}, {}));
+          });
+
+          it("should use default CORS mode", () => {
+            new HTTP(events).request("/");
+
+            expect(fetchStub.firstCall.args[1].mode).eql("cors");
+          });
+
+          it("should use configured custom CORS mode", () => {
+            new HTTP(events, { requestMode: "no-cors" }).request("/");
+
+            expect(fetchStub.firstCall.args[1].mode).eql("no-cors");
+          });
+        });
+
+        describe("Succesful request", () => {
+          beforeEach(() => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, { a: 1 }, { b: 2 }));
+          });
+
+          it("should resolve with HTTP status", async () => {
+            const { status } = await http.request("/");
+            status.should.equal(200);
+          });
+
+          it("should resolve with JSON body", async () => {
+            const { json } = await http.request("/");
+            (json as { a: number }).should.deep.equal({ a: 1 });
+          });
+
+          it("should resolve with headers", async () => {
+            const { headers } = await http.request("/");
+            headers.get("b")!.should.equal(2);
+          });
+        });
+
+        describe("Request timeout", () => {
+          beforeEach(() => {
+            sandbox.stub(global as any, "fetch").returns(
+              new Promise(resolve => {
+                setTimeout(resolve, 20000);
+              })
+            );
+          });
+
+          it("should timeout the request", async () => {
+            await expectAsyncError(
+              () => http.request("/"),
+              undefined,
+              NetworkTimeoutError
+            );
+          });
+
+          it("should show request properties in error", async () => {
+            await expectAsyncError(
+              () =>
+                http.request("/", {
+                  mode: "cors",
+                  headers: {
+                    Authorization: "XXX",
+                    "User-agent": "mocha-test",
+                  },
+                }),
+              'Timeout while trying to access / with {"mode":"cors","headers":{"accept":"application/json","authorization":"**** (suppressed)","content-type":"application/json","user-agent":"mocha-test"}}'
+            );
+          });
+        });
+
+        describe("No content response", () => {
+          it("should resolve with null JSON if Content-Length header is missing", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, null, {}));
+
+            const { json } = await http.request("/");
+            expect(json).to.be.null;
+          });
+        });
+
+        describe("Malformed JSON response", () => {
+          it("should reject with an appropriate message", async () => {
+            sandbox.stub(global as any, "fetch").returns(
+              Promise.resolve({
+                status: 200,
+                headers: {
+                  get(name: string) {
+                    if (name !== "Alert") {
+                      return "fake";
+                    }
+                  },
+                },
+                text() {
+                  return Promise.resolve("an example of invalid JSON");
+                },
+              })
+            );
+
+            await expectAsyncError(
+              () => http.request("/"),
+              /HTTP 200; SyntaxError: Unexpected token.+an example of invalid JSON/,
+              UnparseableResponseError
+            );
+          });
+        });
+
+        describe("Business error responses", () => {
+          it("should reject on status code > 400", async () => {
+            sandbox.stub(global as any, "fetch").returns(
+              fakeServerResponse(400, {
+                code: 400,
+                details: [
+                  {
+                    description: "data is missing",
+                    location: "body",
+                    name: "data",
+                  },
+                ],
+                errno: 107,
+                error: "Invalid parameters",
+                message: "data is missing",
+              })
+            );
+
+            await expectAsyncError(
+              () => http.request("/"),
+              /HTTP 400 Invalid parameters: Invalid request parameter \(data is missing\)/,
+              ServerResponse
+            );
+          });
+
+          it("should expose JSON error bodies", async () => {
+            const errorBody = {
+              code: 400,
+              details: [
+                {
+                  description: "data is missing",
+                  location: "body",
+                  name: "data",
+                },
+              ],
+              errno: 107,
+              error: "Invalid parameters",
+              message: "data is missing",
+            };
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(400, errorBody));
+
+            const error = await expectAsyncError(
+              () => http.request("/"),
+              undefined,
+              ServerResponse
+            );
+            error.should.have.deep.property("data", errorBody);
+          });
+
+          it("should reject on status code > 400 even with empty body", async () => {
+            sandbox.stub(global as any, "fetch").resolves({
+              status: 400,
+              statusText: "Cake Is A Lie",
               headers: {
-                Authorization: "XXX",
-                "User-agent": "mocha-test",
+                get(name: string) {
+                  if (name === "Content-Length") {
+                    return 0;
+                  }
+                },
               },
-            }),
-          'Timeout while trying to access / with {"mode":"cors","headers":{"accept":"application/json","authorization":"**** (suppressed)","content-type":"application/json","user-agent":"mocha-test"}}'
-        );
-      });
-    });
-
-    describe("No content response", () => {
-      it("should resolve with null JSON if Content-Length header is missing", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, null, {}));
-
-        const { json } = await http.request("/");
-        expect(json).to.be.null;
-      });
-    });
-
-    describe("Malformed JSON response", () => {
-      it("should reject with an appropriate message", async () => {
-        sandbox.stub(global as any, "fetch").returns(
-          Promise.resolve({
-            status: 200,
-            headers: {
-              get(name: string) {
-                if (name !== "Alert") {
-                  return "fake";
-                }
+              text() {
+                return Promise.resolve("");
               },
-            },
-            text() {
-              return Promise.resolve("an example of invalid JSON");
-            },
-          })
-        );
+            });
 
-        await expectAsyncError(
-          () => http.request("/"),
-          /HTTP 200; SyntaxError: Unexpected token.+an example of invalid JSON/,
-          UnparseableResponseError
-        );
-      });
-    });
+            await expectAsyncError(
+              () => http.request("/"),
+              /HTTP 400 Cake Is A Lie$/,
+              ServerResponse
+            );
+          });
+        });
 
-    describe("Business error responses", () => {
-      it("should reject on status code > 400", async () => {
-        sandbox.stub(global as any, "fetch").returns(
-          fakeServerResponse(400, {
-            code: 400,
-            details: [
-              {
-                description: "data is missing",
-                location: "body",
-                name: "data",
-              },
-            ],
-            errno: 107,
-            error: "Invalid parameters",
-            message: "data is missing",
-          })
-        );
+        describe("Deprecation header", () => {
+          const eolObject = {
+            code: "soft-eol",
+            url: "http://eos-url",
+            message: "This service will soon be decommissioned",
+          };
 
-        await expectAsyncError(
-          () => http.request("/"),
-          /HTTP 400 Invalid parameters: Invalid request parameter \(data is missing\)/,
-          ServerResponse
-        );
-      });
+          let consoleWarnStub: Stub<typeof console.warn>;
+          let eventsEmitStub: Stub<EventEmitter["emit"]> | null;
 
-      it("should expose JSON error bodies", async () => {
-        const errorBody = {
-          code: 400,
-          details: [
-            {
-              description: "data is missing",
-              location: "body",
-              name: "data",
-            },
-          ],
-          errno: 107,
-          error: "Invalid parameters",
-          message: "data is missing",
-        };
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(400, errorBody));
+          beforeEach(() => {
+            consoleWarnStub = sandbox.stub(console, "warn");
+            eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+          });
 
-        const error = await expectAsyncError(
-          () => http.request("/"),
-          undefined,
-          ServerResponse
-        );
-        error.should.have.deep.property("data", errorBody);
-      });
+          it("should handle deprecation header", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(
+                fakeServerResponse(
+                  200,
+                  {},
+                  { Alert: JSON.stringify(eolObject) }
+                )
+              );
 
-      it("should reject on status code > 400 even with empty body", async () => {
-        sandbox.stub(global as any, "fetch").resolves({
-          status: 400,
-          statusText: "Cake Is A Lie",
-          headers: {
-            get(name: string) {
-              if (name === "Content-Length") {
-                return 0;
+            await http.request("/");
+            sinon.assert.calledOnce(consoleWarnStub);
+            sinon.assert.calledWithExactly(
+              consoleWarnStub,
+              eolObject.message,
+              eolObject.url
+            );
+          });
+
+          it("should handle deprecation header parse error", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, {}, { Alert: "dafuq" }));
+
+            await http.request("/");
+            sinon.assert.calledOnce(consoleWarnStub);
+            sinon.assert.calledWithExactly(
+              consoleWarnStub,
+              "Unable to parse Alert header message",
+              "dafuq"
+            );
+          });
+
+          it("should emit a deprecated event on Alert header", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(
+                fakeServerResponse(
+                  200,
+                  {},
+                  { Alert: JSON.stringify(eolObject) }
+                )
+              );
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("deprecated");
+              expect(eventsEmitStub.firstCall.args[1]).eql(eolObject);
+            }
+          });
+        });
+
+        describe("Backoff header handling", () => {
+          let eventsEmitStub: Stub<EventEmitter["emit"]> | null;
+          beforeEach(() => {
+            // Make Date#getTime always returning 1000000, for predictability
+            sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
+            eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+          });
+
+          it("should emit a backoff event on set Backoff header", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, {}, { Backoff: "1000" }));
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
+            }
+          });
+
+          it("should emit a backoff event even on error responses", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(503, {}, { Backoff: "1000" }));
+
+            try {
+              await http.request("/");
+            } catch (err) {}
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
+            }
+          });
+
+          it("should emit a backoff event on missing Backoff header", async () => {
+            sandbox
+              .stub(global as any, "fetch")
+              .returns(fakeServerResponse(200, {}, {}));
+
+            await http.request("/");
+            if (events && eventsEmitStub) {
+              expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
+              expect(eventsEmitStub.firstCall.args[1]).eql(0);
+            }
+          });
+        });
+
+        describe("Retry-After header handling", () => {
+          let eventsEmitStub: Stub<EventEmitter["emit"]> | null;
+          describe("Event", () => {
+            beforeEach(() => {
+              // Make Date#getTime always returning 1000000, for predictability
+              sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
+              eventsEmitStub = events ? sandbox.stub(events, "emit") : null;
+            });
+
+            it("should emit a retry-after event when Retry-After is set", async () => {
+              sandbox
+                .stub(global as any, "fetch")
+                .returns(
+                  fakeServerResponse(200, {}, { "Retry-After": "1000" })
+                );
+
+              await http.request("/", {}, { retry: 0 });
+              if (events && eventsEmitStub) {
+                expect(eventsEmitStub.lastCall.args[0]).eql("retry-after");
+                expect(eventsEmitStub.lastCall.args[1]).eql(2000000);
               }
-            },
-          },
-          text() {
-            return Promise.resolve("");
-          },
-        });
+            });
+          });
 
-        await expectAsyncError(
-          () => http.request("/"),
-          /HTTP 400 Cake Is A Lie$/,
-          ServerResponse
-        );
-      });
-    });
+          describe("Retry loop", () => {
+            let fetch: sinon.SinonStub;
 
-    describe("Deprecation header", () => {
-      const eolObject = {
-        code: "soft-eol",
-        url: "http://eos-url",
-        message: "This service will soon be decommissioned",
-      };
+            beforeEach(() => {
+              fetch = sandbox.stub(global as any, "fetch");
+              // Avoid actually waiting real time for retries in test suites.
+              // We can't use Sinon fakeTimers since we can't tick the fake
+              // clock at the right moment (just after request failure).
+              sandbox
+                .stub(global, "setTimeout")
+                .callsFake(fn => setImmediate(fn) as any);
+            });
 
-      let consoleWarnStub: Stub<typeof console.warn>;
-      let eventsEmitStub: Stub<typeof events.emit>;
+            it("should not retry the request by default", async () => {
+              fetch.returns(
+                fakeServerResponse(503, {}, { "Retry-After": "1" })
+              );
 
-      beforeEach(() => {
-        consoleWarnStub = sandbox.stub(console, "warn");
-        eventsEmitStub = sandbox.stub(events, "emit");
-      });
+              await expectAsyncError(() => http.request("/"), /HTTP 503/);
+            });
 
-      it("should handle deprecation header", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(
-            fakeServerResponse(200, {}, { Alert: JSON.stringify(eolObject) })
-          );
+            it("should retry the request if specified", async () => {
+              const success = { success: true };
+              fetch
+                .onCall(0)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch.onCall(1).returns(fakeServerResponse(200, success));
 
-        await http.request("/");
-        sinon.assert.calledOnce(consoleWarnStub);
-        sinon.assert.calledWithExactly(
-          consoleWarnStub,
-          eolObject.message,
-          eolObject.url
-        );
-      });
+              const { json } = await http.request("/", {}, { retry: 1 });
+              (json as { success: boolean }).should.deep.equal(success);
+            });
 
-      it("should handle deprecation header parse error", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, {}, { Alert: "dafuq" }));
+            it("should error when retries are exhausted", async () => {
+              fetch
+                .onCall(0)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch
+                .onCall(1)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
+              fetch
+                .onCall(2)
+                .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
 
-        await http.request("/");
-        sinon.assert.calledOnce(consoleWarnStub);
-        sinon.assert.calledWithExactly(
-          consoleWarnStub,
-          "Unable to parse Alert header message",
-          "dafuq"
-        );
-      });
-
-      it("should emit a deprecated event on Alert header", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(
-            fakeServerResponse(200, {}, { Alert: JSON.stringify(eolObject) })
-          );
-
-        await http.request("/");
-        expect(eventsEmitStub.firstCall.args[0]).eql("deprecated");
-        expect(eventsEmitStub.firstCall.args[1]).eql(eolObject);
-      });
-    });
-
-    describe("Backoff header handling", () => {
-      let eventsEmitStub: Stub<typeof events.emit>;
-      beforeEach(() => {
-        // Make Date#getTime always returning 1000000, for predictability
-        sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
-        eventsEmitStub = sandbox.stub(events, "emit");
-      });
-
-      it("should emit a backoff event on set Backoff header", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, {}, { Backoff: "1000" }));
-
-        await http.request("/");
-        expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
-        expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
-      });
-
-      it("should emit a backoff event even on error responses", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(503, {}, { Backoff: "1000" }));
-
-        try {
-          await http.request("/");
-        } catch (err) {}
-        expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
-        expect(eventsEmitStub.firstCall.args[1]).eql(2000000);
-      });
-
-      it("should emit a backoff event on missing Backoff header", async () => {
-        sandbox
-          .stub(global as any, "fetch")
-          .returns(fakeServerResponse(200, {}, {}));
-
-        await http.request("/");
-        expect(eventsEmitStub.firstCall.args[0]).eql("backoff");
-        expect(eventsEmitStub.firstCall.args[1]).eql(0);
-      });
-    });
-
-    describe("Retry-After header handling", () => {
-      let eventsEmitStub: Stub<typeof events.emit>;
-      describe("Event", () => {
-        beforeEach(() => {
-          // Make Date#getTime always returning 1000000, for predictability
-          sandbox.stub(Date.prototype, "getTime").returns(1000 * 1000);
-          eventsEmitStub = sandbox.stub(events, "emit");
-        });
-
-        it("should emit a retry-after event when Retry-After is set", async () => {
-          sandbox
-            .stub(global as any, "fetch")
-            .returns(fakeServerResponse(200, {}, { "Retry-After": "1000" }));
-
-          await http.request("/", {}, { retry: 0 });
-          expect(eventsEmitStub.lastCall.args[0]).eql("retry-after");
-          expect(eventsEmitStub.lastCall.args[1]).eql(2000000);
-        });
-      });
-
-      describe("Retry loop", () => {
-        let fetch: sinon.SinonStub;
-
-        beforeEach(() => {
-          fetch = sandbox.stub(global as any, "fetch");
-          // Avoid actually waiting real time for retries in test suites.
-          // We can't use Sinon fakeTimers since we can't tick the fake
-          // clock at the right moment (just after request failure).
-          sandbox
-            .stub(global, "setTimeout")
-            .callsFake(fn => setImmediate(fn) as any);
-        });
-
-        it("should not retry the request by default", async () => {
-          fetch.returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-
-          await expectAsyncError(() => http.request("/"), /HTTP 503/);
-        });
-
-        it("should retry the request if specified", async () => {
-          const success = { success: true };
-          fetch
-            .onCall(0)
-            .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-          fetch.onCall(1).returns(fakeServerResponse(200, success));
-
-          const { json } = await http.request("/", {}, { retry: 1 });
-          (json as { success: boolean }).should.deep.equal(success);
-        });
-
-        it("should error when retries are exhausted", async () => {
-          fetch
-            .onCall(0)
-            .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-          fetch
-            .onCall(1)
-            .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-          fetch
-            .onCall(2)
-            .returns(fakeServerResponse(503, {}, { "Retry-After": "1" }));
-
-          await expectAsyncError(
-            () => http.request("/", {}, { retry: 2 }),
-            /HTTP 503/
-          );
+              await expectAsyncError(
+                () => http.request("/", {}, { retry: 2 }),
+                /HTTP 503/
+              );
+            });
+          });
         });
       });
     });
-  });
+  }
+
+  runSuite("with EventEmitter", EventEmitter);
+  runSuite("without EventEmitter");
 });


### PR DESCRIPTION
This PR replaces our usage of EventEmitter with an interface with the following shape:

```ts
interface Emitter {
  emit(type: string, event?: any): void;
  on(type: string, handler: (event?: any) => void): void;
  off(type: string, handler: (event?: any) => void): void;
}
```

This allows the consumer to provide their own emitter, or opt not to. For users who opt to use a small emitter like [mitt](https://github.com/developit/mitt), this should result in a decently smaller bundle size.

I also updated the `HTTP` tests to run the entire suite with an `EventEmitter`, with `mitt`, and without an event emitter at all.

Fixes #679 
