### PR TITLE
export SUPPORTED_PROTOCOL_VERSION and Collection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import KintoClientBase, { KintoClientOptions } from "./base";
+import KintoClientBase, { KintoClientOptions, SUPPORTED_PROTOCOL_VERSION } from "./base";
 import { AggregateResponse } from "./batch";
-import type Collection from "./collection";
+import Collection from "./collection";
 import { KintoObject, KintoIdObject, KintoResponse, Permission } from "./types";
 
 export default class KintoClient extends KintoClientBase {
@@ -18,4 +18,5 @@ export {
   AggregateResponse,
   KintoResponse,
   Permission,
+  SUPPORTED_PROTOCOL_VERSION
 };


### PR DESCRIPTION
This PR removes the type-only import of `Collection` since the tests for `kinto.js` rely on having access to the prototype. It also re-exports SUPPORTED_PROTOCOL_VERSION.