### PR TITLE
Add changeset endpoint

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -800,4 +800,21 @@ export default class Collection {
       aggregate: !!options.aggregate,
     });
   }
+
+  @capable(["changes"])
+  async getChangeset<T>(
+    options: {
+      headers?: Record<string, string>;
+      query?: { [key: string]: string };
+      retry?: number;
+    } = {}
+  ): Promise<T> {
+    let path = endpoint.changeset(this.bucket.name, this.name);
+    path = addEndpointOptions(path, options);
+    const request = { headers: this._getHeaders(options), path };
+    const response = (await this.client.execute(request, {
+      retry: this._getRetry(options),
+    })) as T;
+    return response;
+  }
 }

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -16,6 +16,8 @@ const ENDPOINTS = {
     `${ENDPOINTS.collection(bucket, coll)}/records` + (id ? `/${id}` : ""),
   attachment: (bucket: string, coll: string, id: string) =>
     `${ENDPOINTS.record(bucket, coll, id)}/attachment`,
+  changeset: (bucket: string, coll: string) =>
+    `${ENDPOINTS.collection(bucket, coll)}/changeset`,
 };
 
 export default ENDPOINTS;


### PR DESCRIPTION
In [kinto-changes](https://github.com/Kinto/kinto-changes/#endpoints) we added a new `.../changeset` endpoint. 

@glasserc do you think I could add it here? Or I should improve #742 to support that use-case?

Thanks for your feedback :) 