### PR TITLE
Expose execute in bucket and collection classes

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -518,7 +518,6 @@ export default class KintoClientBase {
   /**
    * Executes an atomic HTTP request.
    *
-   * @private
    * @param  {Object}  request             The request object.
    * @param  {String}  request.path        The path to fetch, relative
    *     to the Kinto server root.

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -68,6 +68,19 @@ export default class Bucket {
     this._safe = !!options.safe;
   }
 
+  async execute<T>(
+    request: KintoRequest,
+    options: {
+      raw?: boolean;
+      stringify?: boolean;
+      retry?: number;
+      query?: { [key: string]: string };
+      fields?: string[];
+    } = {}
+  ): Promise<T | HttpResponse<T>> {
+    return this.client.execute(request, options);
+  }
+
   get headers(): Record<string, string> {
     return this._headers;
   }

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -68,17 +68,8 @@ export default class Bucket {
     this._safe = !!options.safe;
   }
 
-  async execute<T>(
-    request: KintoRequest,
-    options: {
-      raw?: boolean;
-      stringify?: boolean;
-      retry?: number;
-      query?: { [key: string]: string };
-      fields?: string[];
-    } = {}
-  ): Promise<T | HttpResponse<T>> {
-    return this.client.execute(request, options);
+  get execute(): KintoClientBase["execute"] {
+    return this.client.execute;
   }
 
   get headers(): Record<string, string> {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -85,6 +85,19 @@ export default class Collection {
     };
   }
 
+  async execute<T>(
+    request: KintoRequest,
+    options: {
+      raw?: boolean;
+      stringify?: boolean;
+      retry?: number;
+      query?: { [key: string]: string };
+      fields?: string[];
+    } = {}
+  ): Promise<T | HttpResponse<T>> {
+    return this.client.execute(request, options);
+  }
+
   /**
    * Get the value of "headers" for a given request, merging the
    * per-request headers with our own "default" headers.

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -85,17 +85,8 @@ export default class Collection {
     };
   }
 
-  async execute<T>(
-    request: KintoRequest,
-    options: {
-      raw?: boolean;
-      stringify?: boolean;
-      retry?: number;
-      query?: { [key: string]: string };
-      fields?: string[];
-    } = {}
-  ): Promise<T | HttpResponse<T>> {
-    return this.client.execute(request, options);
+  get execute(): KintoClientBase["execute"] {
+    return this.client.execute;
   }
 
   /**

--- a/test/bucket_test.ts
+++ b/test/bucket_test.ts
@@ -1157,4 +1157,18 @@ describe("Bucket", () => {
       });
     });
   });
+
+  /** @test {Bucket#execute} */
+  describe("#execute()", () => {
+    it("should rely on client execute", () => {
+      const bucket = getBlogBucket();
+      const executeStub = sandbox.stub();
+      sandbox.stub(client, "execute").get(() => executeStub);
+      const req = { path: "/", headers: {} };
+
+      bucket.execute(req);
+
+      sinon.assert.calledWith(executeStub, req);
+    });
+  });
 });

--- a/test/collection_test.ts
+++ b/test/collection_test.ts
@@ -769,4 +769,17 @@ describe("Collection", () => {
       });
     });
   });
+
+  /** @test {Collection#execute} */
+  describe("#execute()", () => {
+    it("should rely on client execute", () => {
+      const executeStub = sandbox.stub();
+      sandbox.stub(client, "execute").get(() => executeStub);
+      const req = { path: "/", headers: {} };
+
+      coll.execute(req);
+
+      sinon.assert.calledWith(executeStub, req);
+    });
+  });
 });


### PR DESCRIPTION
Instead of having:

```js
const client = new KintoClient(..);
const clientColl = client.bucket(bid).collection(cid);

await clientColl.list();
await client.execute(...);

```

We could just have one reference to the collection instance and still execute raw requests.