### PR TITLE
Fix calls to client.execute() from bucket/collection

### DIFF
--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -69,7 +69,7 @@ export default class Bucket {
   }
 
   get execute(): KintoClientBase["execute"] {
-    return this.client.execute;
+    return this.client.execute.bind(this.client);
   }
 
   get headers(): Record<string, string> {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -86,7 +86,7 @@ export default class Collection {
   }
 
   get execute(): KintoClientBase["execute"] {
-    return this.client.execute;
+    return this.client.execute.bind(this.client);
   }
 
   /**


### PR DESCRIPTION
The previous approach fails with something like `this.http is undefined` 