### PR TITLE
Update compressed size action to v2

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -8,8 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: preactjs/compressed-size-action@v1
+      - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           build-script: "dist"
           compression: "brotli"
+          minimum-change-threshold: 100


### PR DESCRIPTION
This PR updated the compressed size action workflow to v2, which gives us the ability to specify a minimum change threshold. This will help prevent the Gecko build from showing as changed because the git hash in the file is different.