### PR TITLE
Run browser tests on Linux

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Pin ChromeDriver version
         shell: pwsh
         run: |
-          $ver = Get-Content "$($env:CHROMEWEBDRIVER)\versioninfo.txt" | Out-String
+          $ver = chromedriver --version | Out-String | Select-String -Pattern "ChromeDriver (\d+(\.\d+)+)" | % { $_.Matches.Groups[1].Value }
           $con = Get-Content (Join-Path -Path '.' -ChildPath 'intern.json') | Out-String | ConvertFrom-Json
           $con | Add-Member -MemberType NoteProperty -Name "tunnelOptions" -Value @{drivers=@(@{name="chrome"; version=$ver.trim()})}
           $con | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path -Path '.' -ChildPath 'intern.json')

--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -8,7 +8,7 @@ name: Browser Tests
 jobs:
   chore:
     name: Browser Tests
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         browser: [chrome, firefox]
@@ -32,10 +32,10 @@ jobs:
       - name: Pin ChromeDriver version
         shell: pwsh
         run: |
-          $ver = Get-Content "$($env:ChromeWebDriver)\versioninfo.txt" | Out-String
-          $con = Get-Content .\intern.json | Out-String | ConvertFrom-Json
+          $ver = Get-Content "$($env:CHROMEWEBDRIVER)\versioninfo.txt" | Out-String
+          $con = Get-Content (Join-Path -Path '.' -ChildPath 'intern.json') | Out-String | ConvertFrom-Json
           $con | Add-Member -MemberType NoteProperty -Name "tunnelOptions" -Value @{drivers=@(@{name="chrome"; version=$ver.trim()})}
-          $con | ConvertTo-Json -Depth 10 | Set-Content -Path .\intern.json
+          $con | ConvertTo-Json -Depth 10 | Set-Content -Path (Join-Path -Path '.' -ChildPath 'intern.json')
 
       - name: Run tests
         run: npm run test:${{ matrix.browser }}

--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
       - name: Print environment
         run: |
           node --version

--- a/intern.json
+++ b/intern.json
@@ -31,7 +31,7 @@
         {
           "browserName": "chrome",
           "goog:chromeOptions": {
-            "args": ["disk-cache-dir=nul", "headless", "disable-gpu"]
+            "args": ["disk-cache-dir=/dev/null", "headless", "disable-gpu"]
           },
           "fixSessionCapabilities": "no-detect"
         }


### PR DESCRIPTION
Due to the instability of the Firefox tests on Windows, this PR shifts the platform to Linux to see if the stability is any better.