### PR TITLE
Fix #963: Fix snapshot when records were deleted via plural endpoint

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -817,6 +817,7 @@ export default class Collection {
     // Current records ids in the collection.
     const { data: current } = await this.listRecords({
       pages: Infinity,
+      fields: ["id"], // we don't need attributes.
     });
     const currentIds = new Set(current.map((record) => record.id));
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -789,7 +789,7 @@ export default class Collection {
     // we cannot simply rely on the history endpoint.
     // Our strategy here is to clean-up the history entries from the
     // records that were deleted via the plural endpoint.
-    // We will detect them by comparing the currant state of the collection
+    // We will detect them by comparing the current state of the collection
     // and the full history of the collection since its genesis.
 
     // List full history of collection.

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -1839,6 +1839,43 @@ describe("Integration tests", function (__test) {
                 expect(data).eql([rec3, rec2]);
               });
 
+              it("should handle re-creations", async () => {
+                await coll.deleteRecord(rec1.id);
+                await coll.createRecord({ id: rec1.id, n: 1 });
+                const { data } = await coll.listRecords({
+                  at: rec3.last_modified,
+                });
+                expect(data).eql([rec3, rec2, rec1]);
+              });
+
+              it("should handle plural delete before timestamp", async () => {
+                await coll.createRecord({ n: 3 });
+                await coll.deleteRecords({
+                  filters: {
+                    eq_n: 3,
+                  },
+                });
+                const { data: rec4 } = await coll.createRecord({ n: 4 });
+                const { data } = await coll.listRecords({
+                  at: rec4.last_modified,
+                });
+                expect(data).eql([rec4, rec2, rec1]);
+              });
+
+              it("should handle plural delete after timestamp", async () => {
+                const { data: rec33 } = await coll.createRecord({ n: 3 });
+                await coll.createRecord({ n: 4 });
+                await coll.deleteRecords({
+                  filters: {
+                    eq_n: 3,
+                  },
+                });
+                const { data } = await coll.listRecords({
+                  at: rec33.last_modified,
+                });
+                expect(data).eql([rec33, rec3, rec2, rec1]);
+              });
+
               it("should handle long list of changes", async () => {
                 const res = await coll.batch((batch) => {
                   for (let n = 4; n <= 100; n++) {


### PR DESCRIPTION
Unfortunately the fix in #956 was not enough to cover the misbehavior of the Admin UI diff view. I traced it back and it was related to the fact that plural deletes do not generate history entries.

This approach seems to work as expected, and does not introduce too much performance loss

Fixes #963 