### PR TITLE
Add TypeScript types to fetchFunc option

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -29,6 +29,7 @@ import {
   User,
   Emitter,
   HttpMethod,
+  FetchFunction,
 } from "./types";
 import Collection from "./collection";
 
@@ -47,7 +48,7 @@ export interface KintoClientOptions {
   requestMode?: RequestMode;
   timeout?: number;
   batch?: boolean;
-  fetchFunc?: Function;
+  fetchFunc?: FetchFunction;
 }
 
 export interface PaginatedParams {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+import { FetchResponse } from "./types";
+
 /**
  * Kinto server error code descriptors.
  */
@@ -45,11 +47,11 @@ class NetworkTimeoutError extends Error {
 
 class UnparseableResponseError extends Error {
   public status: number;
-  public response: Response;
+  public response: FetchResponse;
   public stack?: string;
   public error: Error;
 
-  constructor(response: Response, body: string, error: Error) {
+  constructor(response: FetchResponse, body: string, error: Error) {
     const { status } = response;
 
     super(
@@ -90,10 +92,10 @@ export interface ServerResponseObject {
  * responses (which become UnparseableResponseErrors, above).
  */
 class ServerResponse extends Error {
-  public response: Response;
+  public response: FetchResponse;
   public data?: ServerResponseObject;
 
-  constructor(response: Response, json?: ServerResponseObject) {
+  constructor(response: FetchResponse, json?: ServerResponseObject) {
     const { status } = response;
     let { statusText } = response;
     let errnoMsg;

--- a/src/http.ts
+++ b/src/http.ts
@@ -5,12 +5,12 @@ import {
   UnparseableResponseError,
   ServerResponseObject,
 } from "./errors";
-import { Emitter } from "./types";
+import { Emitter, FetchFunction, FetchHeaders, FetchResponse } from "./types";
 
 interface HttpOptions {
   timeout?: number | null;
   requestMode?: RequestMode;
-  fetchFunc?: Function;
+  fetchFunc?: FetchFunction;
 }
 
 interface RequestOptions {
@@ -20,7 +20,7 @@ interface RequestOptions {
 export interface HttpResponse<T> {
   status: number;
   json: T;
-  headers: Headers;
+  headers: FetchHeaders;
 }
 
 /**
@@ -52,7 +52,7 @@ export default class HTTP {
   public events?: Emitter;
   public requestMode: RequestMode;
   public timeout: number;
-  public fetchFunc: Function;
+  public fetchFunc: FetchFunction;
 
   /**
    * Constructor.
@@ -93,7 +93,7 @@ export default class HTTP {
   /**
    * @private
    */
-  timedFetch(url: string, options: RequestInit): Promise<Response> {
+  timedFetch(url: string, options: RequestInit): Promise<FetchResponse> {
     let hasTimedout = false;
     return new Promise((resolve, reject) => {
       // Detect if a request has timed out.
@@ -129,7 +129,7 @@ export default class HTTP {
   /**
    * @private
    */
-  async processResponse<T>(response: Response): Promise<HttpResponse<T>> {
+  async processResponse<T>(response: FetchResponse): Promise<HttpResponse<T>> {
     const { status, headers } = response;
     const text = await response.text();
     // Check if we have a body; if so parse it as JSON.
@@ -214,7 +214,7 @@ export default class HTTP {
     }
   }
 
-  _checkForDeprecationHeader(headers: Headers): void {
+  _checkForDeprecationHeader(headers: FetchHeaders): void {
     const alertHeader = headers.get("Alert");
     if (!alertHeader) {
       return;
@@ -232,7 +232,7 @@ export default class HTTP {
     }
   }
 
-  _checkForBackoffHeader(headers: Headers): void {
+  _checkForBackoffHeader(headers: FetchHeaders): void {
     let backoffMs;
     const backoffHeader = headers.get("Backoff");
     const backoffSeconds = backoffHeader ? parseInt(backoffHeader, 10) : 0;
@@ -246,7 +246,7 @@ export default class HTTP {
     }
   }
 
-  _checkForRetryAfterHeader(headers: Headers): number | undefined {
+  _checkForRetryAfterHeader(headers: FetchHeaders): number | undefined {
     const retryAfter = headers.get("Retry-After");
     if (!retryAfter) {
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,3 +115,22 @@ export interface Emitter {
   on(type: string, handler: (event?: any) => void): void;
   off(type: string, handler: (event?: any) => void): void;
 }
+
+export interface FetchHeaders {
+  keys(): IterableIterator<string> | string[];
+  entries(): IterableIterator<[string, string]> | [string, string][];
+  get(name: string): string | null;
+  has(name: string): boolean;
+}
+
+export interface FetchResponse {
+  status: number;
+  statusText: string;
+  text(): Promise<string>;
+  headers: FetchHeaders;
+}
+
+export type FetchFunction = (
+  input: RequestInfo,
+  init?: RequestInit | undefined
+) => Promise<FetchResponse>;

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -19,6 +19,7 @@ export function fakeServerResponse(
   }
   return Promise.resolve({
     status: status,
+    statusText: status === 200 ? "OK" : "Error",
     headers: respHeaders,
     text() {
       return Promise.resolve(JSON.stringify(json));


### PR DESCRIPTION
This PR adds more specific TypeScript types to the `fetchFunc` option.

Using `Function` is the same as `(...args: any) => any`, meaning that any function would be accepted as a valid `fetchFunc`. With this PR, the supplied function will need to conform to the minimal `fetch` interface. Essentially, functions will need to have the following properties:

```ts
export interface FetchHeaders {
  keys(): IterableIterator<string> | string[];
  entries(): IterableIterator<[string, string]> | [string, string][];
  get(name: string): string | null;
  has(name: string): boolean;
}

export interface FetchResponse {
  status: number;
  statusText: string;
  text(): Promise<string>;
  headers: FetchHeaders;
}

export type FetchFunction = (
  input: RequestInfo,
  init?: RequestInit | undefined
) => Promise<FetchResponse>;
```

Most of this should be easily achievable with `XMLHttpRequest`, and even easier if you can reuse the browser's `Headers` class.

I'm fairly confident this also covers all our usage in `kinto.js`, but if not I'll update the types here to ensure that responses from `kinto-http.js` have all the bits that `kinto.js` wants.

(Also, since the new `fetchFunc` option is for Firefox, these types won't be enforced. They will, however, be a good guide to follow when building since they represent all the functionality that `kinto-http.js` expects from `fetch`.)