### PR TITLE
Remove unneeded Github Action steps

### DIFF
--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -16,10 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           node-version: "16.x"
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/browsers.yml
+++ b/.github/workflows/browsers.yml
@@ -24,16 +24,6 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Upgrade Google Chrome
-        run: |
-          version=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE")
-          wget -qP /tmp/ "https://chromedriver.storage.googleapis.com/${version}/chromedriver_linux64.zip"
-          sudo unzip -o /tmp/chromedriver_linux64.zip -d /usr/bin
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
-          sudo apt-get update
-          sudo apt-get --only-upgrade install google-chrome-stable
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           node-version: "16.x"
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           node-version: "16.x"
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           node-version: "16.x"
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
-
       - name: Print environment
         run: |
           node --version

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           node-version: "16.x"
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
       - name: Print environment
         run: |
           node --version


### PR DESCRIPTION
Closes #1190 since the [`ubuntu-latest`](https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20211122.1) and [`windows-latest`](https://github.com/actions/virtual-environments/releases/tag/win19%2F20211122.1) runners now ship with Chrome Driver version 96 (at the time of this PR).

Since these images also [now ship with `Node v16 (LTS)`](https://github.com/actions/virtual-environments/issues/4446) and have shipped with `Python 3.x` for a while, those steps have been removed from action config.